### PR TITLE
FIX:咲夜口上で書式付き文字列が評価されずに出力される問題

### DIFF
--- a/ERB/口上/09 咲夜口上/KOJO_FUNCTION_K9.ERB
+++ b/ERB/口上/09 咲夜口上/KOJO_FUNCTION_K9.ERB
@@ -329,9 +329,9 @@ ENDIF
 咲夜 = NAME_TO_CHARA("咲夜")
 
 IF CHECK_K9("敬語", 咲夜_対象)
-	RETURNF 敬語
+	RETURNF STRFORM(敬語)
 ENDIF
-RETURNF 常体語
+RETURNF STRFORM(常体語)
 
 
 ;─────────────────────────────────────── 


### PR DESCRIPTION
﻿# 概要
咲夜口上で書式付き文字列が評価されずに出力される問題

# もう少し詳しく
## 事象
咲夜の土下座口上にて、以下のような書式付き文字列が表示される
「%CALLNAME_K9(咲夜_対象)%がそう仰るのでしたら、何でも致します」

## 原因
以下のようにKOJO_NIGHT_BOTTOM_K9.ERBにて、式中関数@POLITE_K9の結果を表示しているが
`DATAFORM 「%POLITE_K9("%CALLNAME_K9(咲夜_対象)%がそう言うなら、してみるわ", "%CALLNAME_K9(咲夜_対象)%がそう仰るのでしたら、何でも致します", 咲夜_対象)%」`
@POLITE_K9の式中関数では、文字列をそのまま返しているため

## 対応
@POLITE_K9でSTRFORM関数の展開後の文字列を返す

# 留意点
書式付きと書式なしで呼ばれている@POLITE_K9を幾つかピックアップして確認したが、
敬語常体語分岐がある口上は広範囲に渡っているため完全にテストしていない。

