### PR TITLE
FIX:領地探索と口上の細かい誤記修正

### DIFF
--- a/ERB/SLG/SHOP_SLG/SHOP_SLG71_領地探索_イベント.ERB
+++ b/ERB/SLG/SHOP_SLG/SHOP_SLG71_領地探索_イベント.ERB
@@ -9706,7 +9706,7 @@ ELSEIF RESULT == 1
 			PRINTFORMW 巫女と村人たちに深く感謝された
 			LOCAL = 15 + (DAY / 5)
 			CITY_GUARD:対象都市 -= LOCAL
-			CALL COLORPRINT(@"%CITY_NAME:対象都市%の防衛率が{LOCAL}現象、{CITY_GUARD:対象都市}になった", カラー_注意)
+			CALL COLORPRINT(@"%CITY_NAME:対象都市%の防衛率が{LOCAL}減少、{CITY_GUARD:対象都市}になった", カラー_注意)
 			PRINTFORML 
 			FOR LOCAL, 1, MAX_COUNTRY
 				CALL CHANGE_RELATION_C_TO_C(LOCAL, CFLAG:MASTER:所属, 15, -15)
@@ -9807,7 +9807,7 @@ ELSE
 			PRINTFORMW そのヴァギナは大量の精液を溢れさせだらしなく広がり切ってしまっていたが、命に別状はなかった
 			LOCAL = 15 + (DAY / 5)
 			CITY_GUARD:対象都市 -= LOCAL
-			CALL COLORPRINT(@"%CITY_NAME:対象都市%の防衛率が{LOCAL}現象、{CITY_GUARD:対象都市}になった", カラー_注意, "W")
+			CALL COLORPRINT(@"%CITY_NAME:対象都市%の防衛率が{LOCAL}減少、{CITY_GUARD:対象都市}になった", カラー_注意, "W")
 		ENDIF
 	ENDIF
 ENDIF

--- a/ERB/口上/111 幻月口上/_KOJO_EVENT_K111.ERB
+++ b/ERB/口上/111 幻月口上/_KOJO_EVENT_K111.ERB
@@ -977,7 +977,7 @@ IF ARG == 31
 			
 		CASE 7
 			
-			PRINTFORML [幻月「]強姦も虐殺も、どこでもやってるわ」
+			PRINTFORML [幻月「強姦も虐殺も、どこでもやってるわ」
 			
 		CASE 8
 			


### PR DESCRIPTION
﻿# 概要
イベントと口上の誤記修正

# もう少し詳しく
領地探索「捕まった巫女」の誤字「現象」を「減少」に修正
幻月口上から余分なブラケット削除

# 留意点
なし