### PR TITLE
FIX:自動送金設定で君主配列の範囲外エラー

### DIFF
--- a/ERB/SLG/SLG_FUNCTION.ERB
+++ b/ERB/SLG/SLG_FUNCTION.ERB
@@ -16,6 +16,8 @@ RETURNF LOCAL:1
 ;-------------------------------------------------
 @IS_COUNTRY(ARG:0)
 #FUNCTION
+SIF VARSIZE("COUNTRY_BOSS") <= ARG:0
+	RETURNF 0
 RETURNF COUNTRY_BOSS:(ARG:0) >= 1
 
 ;-------------------------------------------------


### PR DESCRIPTION
﻿# 概要

- 自動送金設定にて、直接入力で君主配列の範囲以上の値を入力したときに、エラー終了する

# もう少し詳しく

- @IS_COUNTRYに引数とサイズのチェックを追加

- エラーログ
```
98[自動送金設定]
99[戻る]
98
----------------------------------------------------------------------------------------------------------------
徴税し国庫が増えたタイミングで、自動で各勢力と会談し送金することができます
国庫が設定額に不足していた場合、あるだけ支払います
徴兵などでも必要になるので、余裕を持たせたほうがよいでしょう
----------------------------------------------------------------------------------------------------------------
[15] 依姫              送金額:なし
[17] 勇儀              送金額:なし
[19] 神綺              送金額:なし
[20] 幻月              送金額:なし
----------------------------------------------------------------------------------------------------------------
[98]一括設定
[99]戻る
1000
SLG\SLG_FUNCTION.ERBの19行目でエラーが発生しました:Emuera1821
RETURNF COUNTRY_BOSS:(ARG:0) >= 1
エラー内容：配列型変数COUNTRY_BOSSの第１引数(1000)は配列の範囲外です
現在の関数：@IS_COUNTRY（SLG\SLG_FUNCTION.ERBの17行目）
関数呼び出しスタック：
↑SLG\SHOP_SLG\SHOP_SLG41_外交_自動送金.ERBの31行目（関数@AUTO_SENDMONEY_SETTING内）
↑SLG\SHOP_SLG\SHOP_SLG41_外交.ERBの158行目（関数@DIPLOMACY内）
↑SLG\SHOP_SLG\SHOP_SLG41_外交.ERBの29行目（関数@SHOP_SLG_EVENTBUY41内）
↑SLG\SHOP_SLG.ERBの56行目（関数@EVENTBUY_SLG内）
↑SHOP\SHOP.ERBの148行目（関数@EVENTBUY内）
```

# 留意点

- 横展開調査は未実施。汚染データに対するチェック機構が欲しいかも
