### PR TITLE
素質による飲酒周りのバリエーション追加・拘束で調教離脱キャンセル

### DIFF
--- a/ERB/TRAIN/COMF/COMF310_酒を飲む.ERB
+++ b/ERB/TRAIN/COMF/COMF310_酒を飲む.ERB
@@ -27,6 +27,9 @@ SIF !(ITEM:濁り酒 || ITEM:清酒 || ITEM:葡萄酒 || ITEM:麦酒 || ITEM:醸
 ;キス中は不可
 SIF IS_EQUIP(MPLY:0, 342)
 	RETURN 0
+;飲まされる側が妊娠していたら不可
+SIF TALENT:(MTAR:0):妊娠
+	RETURN 0
 RETURN 1
 
 ;-------------------------------------------------

--- a/ERB/TRAIN/SOURCE/SOURCE.ERB
+++ b/ERB/TRAIN/SOURCE/SOURCE.ERB
@@ -364,6 +364,23 @@ FOR LOCAL:0, 0, CHARANUM
 				CONTINUE
 			SIF IS_SP_COUNTRY(CFLAG:MASTER:所属) && CFLAG:(LOCAL:0):所属 == CFLAG:MASTER:所属 && GETBIT(TALENT:(LOCAL:0):特殊勢力陥落系, SP_COUNTRY_TO_CONST(CFLAG:MASTER:所属))
 				CONTINUE
+			IF IS_BIND(LOCAL:0)
+				WAIT
+				PRINTL
+				;とりあえず50以上の武闘でランダムで抜け出されることにしたが、もうすこしランダムの比重を減らしたい（さらに体力と気力も加えて計算するか）
+				;縄を使用してた場合アイテムとしての縄が消滅するペナルティがあっても良いかもしれない
+				IF ABL:(LOCAL:0):武闘 > RAND(50, 200)
+					SETCOLOR カラー_警告
+					PRINTFORML %ANAME(LOCAL:0)%は拘束を引き裂いた
+					RESETCOLOR
+				;縄抜け判定失敗につき、離脱キャンセル
+				ELSE
+					SETCOLOR カラー_注意
+					PRINTFORML %ANAME(LOCAL:0)%は拘束を解こうともがいている
+					RESETCOLOR
+					CONTINUE
+				ENDIF
+			ENDIF
 			WAIT
 			PRINTL 
 			PRINTFORMW %ANAME(LOCAL:0)%の怒りが限界に達したようだ
@@ -386,6 +403,8 @@ FOR LOCAL:0, 0, CHARANUM
 			SIF TALENT:(LOCAL:0):特殊勢力素質
 				CONTINUE
 			SIF IS_SP_COUNTRY(CFLAG:MASTER:所属) && CFLAG:(LOCAL:0):所属 == CFLAG:MASTER:所属 && GETBIT(TALENT:(LOCAL:0):特殊勢力陥落系, SP_COUNTRY_TO_CONST(CFLAG:MASTER:所属))
+				CONTINUE
+			SIF IS_BIND(LOCAL:0)
 				CONTINUE
 			WAIT
 			PRINTL 

--- a/ERB/TRAIN/SYSTEM_TRAIN.ERB
+++ b/ERB/TRAIN/SYSTEM_TRAIN.ERB
@@ -137,8 +137,9 @@ IF CONFIG:10
 ENDIF
 
 
-;特殊勢力による調教は、出来上がった状態からスタート
-IF FLAG:調教モード == 調教_逆調教特殊
+;元士官からの逆調教は、既に出来上がった状態からスタート
+IF FLAG:特殊勢力逆調教知り合いフラグ == 1
+	FLAG:特殊勢力逆調教知り合いフラグ = 0
 	FOR LOCAL:0, 0, CHARANUM
 		IF CFLAG:(LOCAL:0):調教参加フラグ
 			PALAM:(LOCAL:0):潤滑 = 30000
@@ -147,10 +148,19 @@ IF FLAG:調教モード == 調教_逆調教特殊
 	NEXT
 ENDIF
 
-;種族名が鬼の場合、たまに酔っ払った状態でスタート
+;下戸でなく妊娠していなかったら、たまに酔っ払った状態でスタート
+;種族名が鬼の場合高確率、酒豪でもそこそこの確率
+;ただし鬼じゃない場合、捕虜調教時は含めない
 FOR LOCAL, 0, CHARANUM
-	SIF CFLAG:(LOCAL:0):調教参加フラグ && HAS_TAG(LOCAL:0, タグ_鬼) && !RAND:3
-		PALAM:(LOCAL:0):酔い = RAND(3000, 6000)
+	IF CFLAG:(LOCAL:0):調教参加フラグ && !TALENT:(LOCAL:0):下戸 && !TALENT:(LOCAL:0):妊娠
+		IF CSTR:(LOCAL:0):8 == "鬼" && !RAND:3
+			PALAM:(LOCAL:0):酔い = RAND(3000, 6000)
+		ELSEIF TALENT:(LOCAL:0):酒豪 && FLAG:調教モード != 2 && !RAND:5
+			PALAM:(LOCAL:0):酔い = RAND(1500, 3000)
+		ELSEIF FLAG:調教モード != 2 && !RAND:10
+			PALAM:(LOCAL:0):酔い = RAND(500, 1500)
+		ENDIF
+	ENDIF
 NEXT
 
 


### PR DESCRIPTION
﻿# 概要
* UPDATE:飲まされる側が妊娠してた場合「酒を飲む」コマンドが選べなくなる。被捕虜調教でなければ鬼でなくても調教開始時低確率で酔いスタート。（酒豪1/5で中酔い・通常1/10で浅酔い）下戸や妊娠時は鬼でも飲まなくなる。
* UPDATE:縄などで拘束してた場合、怒りや哀しみによる強制調教離脱をキャンセルできる。ただし怒りでは武闘ベース＆確率で離脱される。
離脱判定がランダム性が強いので、要調整。（体力と気力も計算に加えるのはどうか）