### PR TITLE
「能力一覧」画面の表示ズレHOTFIX

### DIFF
--- a/ERB/SHOP/SHOP_LIFE/SHOP_LIFE51_能力表示_一覧.ERB
+++ b/ERB/SHOP/SHOP_LIFE/SHOP_LIFE51_能力表示_一覧.ERB
@@ -5,12 +5,18 @@
 @SHOP_LIFE_CHARA_TABLE
 #DIM CHARA_TABLE,3000
 #DIM SORT_VALUE,3000
-#DIM HEAD_SLG = GETNUM(ABL, "武闘"), GETNUM(ABL, "防衛"), GETNUM(ABL, "知略"), GETNUM(ABL, "政治"), GETNUM(ABL, "妖術"), GETNUM(ABL, "歌唱"), GETNUM(ABL, "料理")
+{
+#DIM HEAD_SLG =
+GETNUM(ABL, "武闘"), GETNUM(ABL, "防衛"), GETNUM(ABL, "知略"), GETNUM(ABL, "政治"),
+GETNUM(ABL, "妖術"), GETNUM(ABL, "歌唱"), GETNUM(ABL, "料理"), GETNUM(ABL, "野心")
+}
+
 {
 #DIM HEAD_ABL =
 GETNUM(ABL, "Ｃ感"), GETNUM(ABL, "Ｖ感"), GETNUM(ABL, "Ａ感"), GETNUM(ABL, "Ｂ感"), GETNUM(ABL, "Ｍ感"),
 GETNUM(ABL, "欲望"), GETNUM(ABL, "性技"), GETNUM(ABL, "性知識")
 }
+
 #DIM HEAD_BASE = GETNUM(BASE, "体力"), GETNUM(BASE, "気力"), GETNUM(BASE, "精神力")
 
 {
@@ -19,10 +25,12 @@ GETNUM(ABL, "奉仕"), GETNUM(ABL, "性交"), GETNUM(ABL, "レズ"), GETNUM(ABL,
 GETNUM(ABL, "自慰"), GETNUM(ABL, "精愛"), GETNUM(ABL, "射精"), GETNUM(ABL, "噴乳"), GETNUM(ABL, "排泄"),
 GETNUM(ABL, "触手"), GETNUM(ABL, "出産")
 }
+
 {
 #DIM HEAD_CFLAG = 
 GETNUM(CFLAG, "好感度"), GETNUM(CFLAG, "依存度"), GETNUM(CFLAG, "従属度")
 }
+
 #DIM FIRST_LINE
 #DIM DESC
 #DIM NOW_SORT
@@ -270,20 +278,27 @@ GOTO INPUT_LOOP
 ;ボタンの選択番号は NO + ARG:2 になる
 ;-------------------------------------------------
 @PRINT_PARTNER_DATA_TABLE(ARG:0, ARG:1 = 0, ARG:2 = 100)
-#DIM HEAD_SLG = GETNUM(ABL, "武闘"), GETNUM(ABL, "防衛"), GETNUM(ABL, "知略"), GETNUM(ABL, "政治"), GETNUM(ABL, "妖術"), GETNUM(ABL, "歌唱"), GETNUM(ABL, "料理")
+{
+#DIM HEAD_SLG =
+GETNUM(ABL, "武闘"), GETNUM(ABL, "防衛"), GETNUM(ABL, "知略"), GETNUM(ABL, "政治"),
+GETNUM(ABL, "妖術"), GETNUM(ABL, "歌唱"), GETNUM(ABL, "料理"), GETNUM(ABL, "野心")
+}
+
 {
 #DIM HEAD_ABL =
 GETNUM(ABL, "Ｃ感"), GETNUM(ABL, "Ｖ感"), GETNUM(ABL, "Ａ感"), GETNUM(ABL, "Ｂ感"), GETNUM(ABL, "Ｍ感"),
 GETNUM(ABL, "欲望"), GETNUM(ABL, "性技"), GETNUM(ABL, "性知識")
 }
+
 #DIM HEAD_BASE = GETNUM(BASE, "体力"), GETNUM(BASE, "気力"), GETNUM(BASE, "精神力")
 
 {
 #DIM HEAD_ABL_2 =
 GETNUM(ABL, "奉仕"), GETNUM(ABL, "性交"), GETNUM(ABL, "レズ"), GETNUM(ABL, "ＢＬ"), GETNUM(ABL, "露出"),
-GETNUM(ABL, "自慰"), GETNUM(ABL, "性交"), GETNUM(ABL, "精愛"), GETNUM(ABL, "射精"), GETNUM(ABL, "噴乳"),
-GETNUM(ABL, "排泄"), GETNUM(ABL, "触手"), GETNUM(ABL, "出産")
+GETNUM(ABL, "自慰"), GETNUM(ABL, "精愛"), GETNUM(ABL, "射精"), GETNUM(ABL, "噴乳"), GETNUM(ABL, "排泄"),
+GETNUM(ABL, "触手"), GETNUM(ABL, "出産")
 }
+
 {
 #DIM HEAD_CFLAG = 
 GETNUM(CFLAG, "好感度"), GETNUM(CFLAG, "依存度"), GETNUM(CFLAG, "従属度")
@@ -301,6 +316,7 @@ SELECTCASE ARG:1
 			CALL PRINT_ALPHABET_RANK(ランク_ＳＬＧ, ABL:(ARG:0):(HEAD_SLG:LOCAL))
 			PRINTFORM {ABL:(ARG:0):(HEAD_SLG:LOCAL), 4}
 		NEXT
+		PRINT |
 	CASE 2
 		FOR LOCAL, 0, VARSIZE("HEAD_ABL")
 			IF HEAD_ABL:LOCAL == GETNUM(ABL, "性知識")


### PR DESCRIPTION
﻿# 概要
FIX:「能力一覧」画面において、「性交」が二重に表示される問題、ヘッダ部分しか直されてなかったので全体をちゃんと修正
ADD:ついでに「野心」の表示を追加