### PR TITLE
子供がふたなる率追加／ふたなり表示色調整

### DIFF
--- a/ERB/R_CHARA/CHILD.ERB
+++ b/ERB/R_CHARA/CHILD.ERB
@@ -59,9 +59,19 @@ TALENT:子供体型 = 1
 
 ;設定された男性率に応じて性別を設定
 IF RAND:100 < CONFIG:4
-	TALENT:性別 = 0
+	IF RAND:30 == 0
+		TALENT:性別 = 4
+	ELSEIF RAND:30 == 0
+		TALENT:性別 = 3
+	ELSE
+		TALENT:性別 = 0
+	ENDIF
 ELSE
-	TALENT:性別 = 1
+	IF RAND:20 == 0
+		TALENT:性別 = 2
+	ELSE
+		TALENT:性別 = 1
+	ENDIF
 	TALENT:絶壁 = 1
 ENDIF
 

--- a/ERB/SYSTEM/COLOR.ERH
+++ b/ERB/SYSTEM/COLOR.ERH
@@ -5,8 +5,8 @@
 
 #DIM CONST カラー_男 = 0x8000FF
 #DIM CONST カラー_女 = 0xFF0080
-#DIM CONST カラー_男双 = 0xFF00BF
-#DIM CONST カラー_女双 = 0xB000FF
+#DIM CONST カラー_男双 = 0xB000FF
+#DIM CONST カラー_女双 = 0xFF00BF
 #DIM CONST カラー_男の娘 = 0x40C0FF
 #DIM CONST カラー_男の娘双 = 0xFF80FF
 #DIM CONST カラー_性別不明 = 0x808080


### PR DESCRIPTION
﻿# 概要
* UPDATE:子供の性別にランダムキャラ生成と同じふたなり・男の娘率を適応
※今後、ふたなり・男の娘が親の場合、子供のふたなり・男の娘率に影響を及ぼすようにする予定
* FIX:男ふたなりと女ふたなりのインターフェイス表示色が逆に感じたので入れ替え（男女のカラーに近いよう、男双は紫・女双はピンクになるようにしました）