### PR TITLE
特殊勢力のランダムキャラにざっくり個性追加

### DIFF
--- a/ERB/SYSTEM/SP_COUNTRY/SP_COUNTRY_FUNCTIONS.ERB
+++ b/ERB/SYSTEM/SP_COUNTRY/SP_COUNTRY_FUNCTIONS.ERB
@@ -464,7 +464,16 @@ IF ボス
 		TALENT:対象:性別 = 2
 ELSE
 	IF 勢力定数 == 特殊勢力_サキュバス
-		TALENT:対象:性別 = RAND:2 + 1
+		SELECTCASE RAND:100
+			CASE IS < 40
+				TALENT:対象:性別 = 1
+			CASE IS < 80
+				TALENT:対象:性別 = 2
+			CASE IS < 90
+				TALENT:対象:性別 = 4
+			CASE IS < 100
+				TALENT:対象:性別 = 5
+		ENDSELECT
 	ELSEIF GROUPMATCH(勢力定数, 特殊勢力_外来人, 特殊勢力_自警団, 特殊勢力_触手, 特殊勢力_狂信者)
 		SELECTCASE RAND:100
 			CASE IS < 60
@@ -533,7 +542,9 @@ SELECTCASE 勢力定数
 		ABL:対象:奉仕 = 4
 		ABL:対象:性交 = 2
 		ABL:対象:露出 = 3
-		ABL:対象:射精 = 3
+		IF HAS_PENIS(対象)
+			ABL:対象:射精 = 3
+		ENDIF
 		ABL:対象:排泄 = 2
 		ABL:対象:主導度Ｕ = 700
 		ABL:対象:主導度Ｎ = 300
@@ -544,21 +555,28 @@ SELECTCASE 勢力定数
 		IF IS_FEMALE(対象)
 			ABL:対象:Ｂ感 = 3
 			ABL:対象:Ｖ感 = 4
-			ABL:対象:Ａ感 = 2
-			ABL:対象:Ｍ感 = 3
 		ENDIF
+		ABL:対象:Ａ感 = 2
+		ABL:対象:Ｍ感 = 3
 		ABL:対象:欲望 = 7
 		ABL:対象:性技 = 1
 		ABL:対象:性知識 = 5
 		ABL:対象:奉仕 = 2
 		ABL:対象:性交 = 6
 		ABL:対象:露出 = 1
-		ABL:対象:射精 = 6
+		IF HAS_PENIS(対象)
+			ABL:対象:射精 = 6
+		ENDIF
+		ABL:対象:噴乳 = 1
 		ABL:対象:排泄 = 2
+		ABL:対象:触手 = RAND(1, 5)
 		ABL:対象:主導度Ｕ = 500
 		ABL:対象:主導度Ｎ = 300
 		ABL:対象:倒錯度 = 300
 		EXP:対象:絶頂経験 = 500
+		IF HAS_VAGINA(対象)
+			EXP:対象:触手出産経験 = RAND(10)
+		ENDIF
 	CASE 特殊勢力_自警団
 		ABL:対象:Ｃ感 = 2
 		IF IS_FEMALE(対象)
@@ -573,7 +591,9 @@ SELECTCASE 勢力定数
 		ABL:対象:奉仕 = 2
 		ABL:対象:性交 = 1
 		ABL:対象:露出 = 1
-		ABL:対象:射精 = 2
+		IF HAS_PENIS(対象)
+			ABL:対象:射精 = 2
+		ENDIF
 		ABL:対象:排泄 = 1
 		ABL:対象:主導度Ｕ = RAND(-300, 300)
 		ABL:対象:主導度Ｎ = RAND(-300, 300)
@@ -581,8 +601,10 @@ SELECTCASE 勢力定数
 		EXP:対象:絶頂経験 = 100
 	CASE 特殊勢力_サキュバス
 		ABL:対象:Ｃ感 = 3
-		ABL:対象:Ｂ感 = 3
-		ABL:対象:Ｖ感 = 3
+		IF IS_FEMALE(対象)
+			ABL:対象:Ｂ感 = 3
+			ABL:対象:Ｖ感 = 3
+		ENDIF
 		ABL:対象:Ａ感 = 3
 		ABL:対象:Ｍ感 = 3
 		ABL:対象:欲望 = 5
@@ -613,7 +635,9 @@ SELECTCASE 勢力定数
 		ABL:対象:奉仕 = 2
 		ABL:対象:性交 = 5
 		ABL:対象:露出 = 2
-		ABL:対象:射精 = 4
+		IF HAS_PENIS(対象)
+			ABL:対象:射精 = 4
+		ENDIF
 		ABL:対象:排泄 = 2
 		ABL:対象:主導度Ｕ = 700
 		ABL:対象:主導度Ｎ = 300


### PR DESCRIPTION
﻿# 概要
UPDATE:サキュバス勢に1/5の確率で男の娘・男の娘双が発生する（女:女双:男娘:男娘双 = 4:4:1:1）
UPDATE:特殊勢力のランダムキャラ「ABL:射精」は「HAS_PENIS」であったときのみ加算
UPDATE:サキュバス勢と触手勢のランダムキャラの「CAM感」は男性にも適応。「BV感」は女性のみ。
UPDATE:触手勢のランダムキャラの触手関係ABL・EXP追加


