### PR TITLE
Fix 口上デイリー「乞食？」内の一部イベントの発生条件を修正

### DIFF
--- a/ERB/口上/02 魔理沙口上/DAILY/_KOJO_DAILY_K2_再会.ERB
+++ b/ERB/口上/02 魔理沙口上/DAILY/_KOJO_DAILY_K2_再会.ERB
@@ -50,11 +50,11 @@ PRINTFORMW 「うぉお！　勘弁してくれよ%ANAME(魅魔)%様！？」
 PRINTFORMW %ANAME(対象)%と再会した%ANAME(魅魔)%は、かつての弟子に再び稽古をつけることにしたようだ
 PRINTFORMW 訓練は丸一日中続いた……
 
-CALL COLORPRINT(@"%ANAME(MASTER)%の武闘が3上昇した", カラー_注意, "W")
+CALL COLORPRINT(@"%ANAME(対象)%の武闘が3上昇した", カラー_注意, "W")
 ABL:対象:武闘 += 3
-CALL SKILL_LEARN_BY_NAME(MASTER, スキル_ジャンル_PASSIVE, 0, "超成長力")
+CALL SKILL_LEARN_BY_NAME(対象, スキル_ジャンル_PASSIVE, 0, "超成長力")
 SIF RESULT
-	CALL COLORPRINT(@"%ANAME(MASTER)%は＜超成長力＞を得た", カラー_注意, "W")
+	CALL COLORPRINT(@"%ANAME(対象)%は＜超成長力＞を得た", カラー_注意, "W")
 CALL ADD_COOLTIME(対象, 3)
 
 KDVAR:対象:魔理沙_再会 = 1

--- a/ERB/口上/150 紫苑口上/DAILY/_KOJO_DAILY_K150_乞食？.ERB
+++ b/ERB/口上/150 紫苑口上/DAILY/_KOJO_DAILY_K150_乞食？.ERB
@@ -72,7 +72,7 @@ PRINTFORML 「助けてもらったお礼とか、させてもらえないかな
 PRINTFORML 「といっても、私は妹みたいにどこかからお金をぶんどってきたりは出来ないんだけど……」
 PRINTFORML なにか物騒な単語が聞こえた気がしたが、さてどうしようか……
 PRINTFORML 
-CALL ASK_MULTI_JUDGE("仲間になって", 1, "何か教えて", 1, "ヤらせて！", IS_MALE(対象), "いらない")
+CALL ASK_MULTI_JUDGE("仲間になって", 1, "何か教えて", 1, "ヤらせて！", IS_MALE(MASTER), "いらない")
 
 SELECTCASE RESULT
     CASE 0


### PR DESCRIPTION
﻿# 概要
選択肢 "ヤらせて！" の発生条件を IS_MALE(対象) から IS_MALE(MASTER) に修正