### PR TITLE
Fix 口上デイリー「乞食？」内の一部選択肢の発生条件を修正

### DIFF
--- a/ERB/口上/150 紫苑口上/DAILY/_KOJO_DAILY_K150_乞食？.ERB
+++ b/ERB/口上/150 紫苑口上/DAILY/_KOJO_DAILY_K150_乞食？.ERB
@@ -72,7 +72,7 @@ PRINTFORML 「助けてもらったお礼とか、させてもらえないかな
 PRINTFORML 「といっても、私は妹みたいにどこかからお金をぶんどってきたりは出来ないんだけど……」
 PRINTFORML なにか物騒な単語が聞こえた気がしたが、さてどうしようか……
 PRINTFORML 
-CALL ASK_MULTI_JUDGE("仲間になって", 1, "何か教えて", 1, "ヤらせて！", IS_MALE(対象), "いらない")
+CALL ASK_MULTI_JUDGE("仲間になって", 1, "何か教えて", 1, "ヤらせて！", IS_MALE(MASTER), "いらない")
 
 SELECTCASE RESULT
     CASE 0


### PR DESCRIPTION
﻿# 概要
選択肢 "ヤらせて！" の発生条件を IS_MALE(対象) から IS_MALE(MASTER) に修正
