### PR TITLE
 汎用実行判定に血縁関係による補正を追加

### DIFF
--- a/ERB/TRAIN/COMF/COMF390_二人で出掛ける.ERB
+++ b/ERB/TRAIN/COMF/COMF390_二人で出掛ける.ERB
@@ -158,7 +158,7 @@ CALL DATE_START_BYPLACE
 TSTR:0 = %TRAIN_PLACE%
 TRAIN_PLACE = %GET_PLACENAME(TFLAG:54)%
 
-SIF CFLAG:対象:行動不能状態 != 行動不能_子供 || !TALENT:(MTAR:0):幼児
+SIF CFLAG:(MTAR:0):行動不能状態 != 行動不能_子供 || !TALENT:(MTAR:0):幼児
 	TFLAG:56 += 3
 
 ;経過時間のカウント開始

--- a/ERB/TRAIN/COMF/_COMORDER.ERB
+++ b/ERB/TRAIN/COMF/_COMORDER.ERB
@@ -359,6 +359,13 @@ IF TCVAR:(ARG:0):催眠中 > 0
 	CALL COM_ORDER_ELEMENT(ARG:0, "催眠術", LOCAL:0)
 ENDIF
 
+;血縁関係
+IF IS_FATHER(ARG:0, MASTER) || IS_MOTHER(ARG:0, MASTER) || IS_FATHER(MASTER, ARG:0) || IS_MOTHER(MASTER, ARG:0)
+	CALL COM_ORDER_ELEMENT(ARG:0, "親子", 20)
+ELSEIF IS_PURE_BROTHER(ARG:0, MASTER)
+	CALL COM_ORDER_ELEMENT(ARG:0, "兄弟姉妹", 20)
+ENDIF
+
 ;-------------------------------------------------
 ;膣性交の実行判定(Ｐ側)
 ;-------------------------------------------------


### PR DESCRIPTION
﻿# 概要
@COM_ORDERにIS_FATHER,IS_MOTHERを利用した親子補正とIS_PURE_BROTHERを利用した兄弟姉妹補正を追加

FIX:COMF390で利用出来ない対象の修正のコミットを含む