### PR TITLE
ADD:汎用実行判定に血縁関係による補正を追加

### DIFF
--- a/ERB/TRAIN/COMF/_COMORDER.ERB
+++ b/ERB/TRAIN/COMF/_COMORDER.ERB
@@ -359,6 +359,13 @@ IF TCVAR:(ARG:0):催眠中 > 0
 	CALL COM_ORDER_ELEMENT(ARG:0, "催眠術", LOCAL:0)
 ENDIF
 
+;血縁関係
+IF IS_FATHER(ARG:0, MASTER) || IS_MOTHER(ARG:0, MASTER) || IS_FATHER(MASTER, ARG:0) || IS_MOTHER(MASTER, ARG:0)
+	CALL COM_ORDER_ELEMENT(ARG:0, "親子", 20)
+ELSEIF IS_PURE_BROTHER(ARG:0, MASTER)
+	CALL COM_ORDER_ELEMENT(ARG:0, "兄弟姉妹", 20)
+ENDIF
+
 ;-------------------------------------------------
 ;膣性交の実行判定(Ｐ側)
 ;-------------------------------------------------


### PR DESCRIPTION
﻿# 概要
@COM_ORDERにIS_FATHER,IS_MOTHERを利用した親子補正とIS_PURE_BROTHERを利用した兄弟姉妹補正を追加