### PR TITLE
FIX:放浪中にコマンド「忠誠を誓わせる」が実行出来る問題

### DIFF
--- a/ERB/TRAIN/COMF/COMF299_忠誠を誓わせる.ERB
+++ b/ERB/TRAIN/COMF/COMF299_忠誠を誓わせる.ERB
@@ -43,6 +43,9 @@ SIF IS_M_HOLD(MPLY:0)
 ;ターゲットの口が塞がっているなら不可
 SIF IS_M_HOLD(MTAR:0)
 	RETURN 0
+;プレイヤーが放浪中は不可
+SIF !CFLAG:MASTER:所属
+	RETURN 0
 RETURN 1
 
 ;-------------------------------------------------


### PR DESCRIPTION
﻿# 概要
放浪中にコマンド「忠誠を誓わせる」を実行することで強制的に相手を放浪させられるバグを修正