### PR TITLE
FIX:拠点フェイズのメニューから選択する「捕虜の扱い」で説得が正常に表示されない問題

### DIFF
--- a/ERB/SHOP/SHOP_LIFE/SHOP_LIFE33_捕虜の扱い.ERB
+++ b/ERB/SHOP/SHOP_LIFE/SHOP_LIFE33_捕虜の扱い.ERB
@@ -58,7 +58,7 @@ CALL SHOP_LIFE_BUTTON33(ARG:0, CFLAG:(ARG:0):軟禁中 == 0 && CFLAG:(ARG:0):捕
 CALL SHOP_LIFE_BUTTON33(ARG:0, CFLAG:(ARG:0):軟禁中 == 1 && CFLAG:(ARG:0):捕虜の扱い == 0, 2, "軟禁")
 CALL SHOP_LIFE_BUTTON33(ARG:0, CFLAG:(ARG:0):軟禁中 == 0 && CFLAG:(ARG:0):捕虜の扱い == 2, 3, "拷問")
 CALL SHOP_LIFE_BUTTON33(ARG:0, CFLAG:(ARG:0):軟禁中 == 0 && CFLAG:(ARG:0):捕虜の扱い == 3, 4, "身体開発")
-CALL SHOP_LIFE_BUTTON33(ARG:0, CFLAG:(ARG:0):軟禁中 == 0 && CFLAG:(ARG:0):捕虜の扱い == 3, 5, "説得")
+CALL SHOP_LIFE_BUTTON33(ARG:0, CFLAG:(ARG:0):軟禁中 == 0 && CFLAG:(ARG:0):捕虜の扱い == 4, 5, "説得")
 CALL SHOP_LIFE_BUTTON33(ARG:0, CFLAG:(ARG:0):軟禁中 == 0 && CFLAG:(ARG:0):捕虜の扱い == 5, 6, "性処理")
 IF SYOKUSYU_FLAG
 	CALL SHOP_LIFE_BUTTON33(ARG:0, CFLAG:(ARG:0):軟禁中 == 0 && CFLAG:(ARG:0):捕虜の扱い == 6, 7, "触手")


### PR DESCRIPTION
﻿# 概要
FIX:拠点フェイズのメニューから選択する「捕虜の扱い」で説得が正常に表示されない問題
# もう少し詳しく
選択中色フラグの判定で身体開発の値を判定していた