### PR TITLE
UPDATE:[主導操作の法]で操作する値の名称・順番を[能力表示]で表示されるものに変更

### DIFF
--- a/ERB/SHOP/SHOP_LIFE/SHOP_LIFE71_アイテム_キャラ選択.ERB
+++ b/ERB/SHOP/SHOP_LIFE/SHOP_LIFE71_アイテム_キャラ選択.ERB
@@ -1,4 +1,4 @@
-﻿;	-----------------------------------------------
+;-------------------------------------------------
 ;対象キャラを選択するアイテムの使用条件
 ;-------------------------------------------------
 ;●ふたなり薬
@@ -725,9 +725,9 @@ ENDIF
 #DIM 操作後値
 FIRST_LINE = LINECOUNT
 PRINTFORML %ANAME(ARG:0)%に主導操作を行う……
-PRINTFORML [0] 主導度Ｕ
-PRINTFORML [1] 主導度Ｎ
-PRINTFORML [2] 倒錯度
+PRINTFORML [0] 昼主導度
+PRINTFORML [1] 夜倒錯度
+PRINTFORML [2] 夜主導度
 
 INPUT
 
@@ -740,7 +740,7 @@ ENDIF
 
 PRINTFORML いくらにしようか……
 
-IF GROUPMATCH(操作項目, 0, 1)
+IF GROUPMATCH(操作項目, 0, 2)
 	PRINTFORML (-1000 ～ 1000で入力、範囲外でキャンセル)
 ELSE
 	PRINTFORML (0 ～ 1000で入力、範囲外でキャンセル)
@@ -748,7 +748,7 @@ ENDIF
 
 INPUT
 
-IF (GROUPMATCH(操作項目, 0, 1) && !INRANGE(RESULT, -1000, 1000)) || (操作項目 == 2 && !INRANGE(RESULT, 0, 1000))
+IF (GROUPMATCH(操作項目, 0, 2) && !INRANGE(RESULT, -1000, 1000)) || (操作項目 == 1 && !INRANGE(RESULT, 0, 1000))
 	CLEARLINE LINECOUNT - FIRST_LINE
 	RESTART
 ENDIF
@@ -757,14 +757,14 @@ ENDIF
 
 SELECTCASE 操作項目
 	CASE 0
-		PRINTFORMW %ANAME(ARG:0)%の主導度Ｕが{操作後値}になりました
-		ABL:(ARG:0):主導度Ｕ = 操作後値
-	CASE 1
-		PRINTFORMW %ANAME(ARG:0)%の主導度Ｎが{操作後値}になりました
+		PRINTFORMW %ANAME(ARG:0)%の昼主導度が{操作後値}になりました
 		ABL:(ARG:0):主導度Ｎ = 操作後値
-	CASE 2
-		PRINTFORMW %ANAME(ARG:0)%の倒錯度が{操作後値}になりました
+	CASE 1
+		PRINTFORMW %ANAME(ARG:0)%の夜倒錯度が{操作後値}になりました
 		ABL:(ARG:0):倒錯度 = 操作後値
+	CASE 2
+		PRINTFORMW %ANAME(ARG:0)%の夜主導度が{操作後値}になりました
+		ABL:(ARG:0):主導度Ｕ = 操作後値
 ENDSELECT
 
 ;●太平要術の書


### PR DESCRIPTION
﻿# 概要
[主導操作の法]の主導度・倒錯度の名称や順番が[能力表示]の表示と違ったため、
ゲーム内で統一するべきだと考え変更した。
ついでに一行目のコメントアウトの部分の表記が少しずれていたのを修正。

# もう少し詳しく
[0] 主導度Ｕ
[1] 主導度Ｎ
[2] 倒錯度

これが元の[主導操作の法]のUIだが、

[0] 昼主導度
[1] 夜倒錯度
[2] 夜主導度

変更後はこのように[能力表示]と同様の名称と順番になる。

# 留意点
個人的なわかりやすさを優先した変更なので、
何か問題があれば却下で。
