### PR TITLE
FIX:STAINにかかわる処理の削除

### DIFF
--- a/ERB/SYSTEM/_FUNCTION.ERB
+++ b/ERB/SYSTEM/_FUNCTION.ERB
@@ -1359,49 +1359,6 @@ ELSE
 	RETURNF 0
 ENDIF
 
-;-------------------------------------------------
-;ARG:0番のキャラの指定部位に指定の汚れがあるかどうかを返す
-;ARGS:1 = 部位名称、ARGS:2～6 = 汚れ名称
-;-------------------------------------------------
-@GET_STAIN(ARG:0, ARGS:1, ARGS:2, ARGS:3 = "", ARGS:4 = "", ARGS:5 = "", ARGS:6 = "")
-#FUNCTION
-IF ARGS:1 == "口"
-	LOCAL:0 = 0
-ELSEIF ARGS:1 == "手"
-	LOCAL:0 = 1
-ELSEIF ARGS:1 == "Ｐ"
-	LOCAL:0 = 2
-ELSEIF ARGS:1 == "Ｖ"
-	LOCAL:0 = 3
-ELSEIF ARGS:1 == "Ａ"
-	LOCAL:0 = 4
-ELSEIF ARGS:1 == "Ｂ"
-	LOCAL:0 = 5
-ELSE
-	THROW "@GET_STAINに指定された部位名称%ARGS:1%は解釈出来ません"
-ENDIF
-
-LOCAL:3 = 0
-FOR LOCAL:2, 2, 7
-	IF LOCAL:2 > 2 && ARGS:(LOCAL:2) != ""
-		BREAK
-	ELSEIF ARGS:(LOCAL:2) == "Ｖ"
-		LOCAL:1 = 0
-	ELSEIF ARGS:(LOCAL:2) == "Ｐ"
-		LOCAL:1 = 1
-	ELSEIF ARGS:(LOCAL:2) == "精"
-		LOCAL:1 = 2
-	ELSEIF ARGS:(LOCAL:2) == "Ａ"
-		LOCAL:1 = 3
-	ELSEIF ARGS:(LOCAL:2) == "乳"
-		LOCAL:1 = 4
-	ELSE
-		THROW "@GET_STAINに指定された汚れ名称%ARGS:(LOCAL:2)%は解釈出来ません"
-	ENDIF
-	LOCAL:3 |= (STAIN:(ARG:0):(LOCAL:0) & (1 << LOCAL:1))
-NEXT
-
-RETURNF LOCAL:3 != 0
 
 ;-------------------------------------------------
 ;性別の値ARG:0を文字列として返す

--- a/ERB/TRAIN/COMF/COMF0_愛撫.ERB
+++ b/ERB/TRAIN/COMF/COMF0_愛撫.ERB
@@ -154,7 +154,6 @@ NEXT
 ;1-1のときのみキスを追加
 IF MPLY_NUM == 1 && MTAR_NUM == 1
 	;どちらもキス未経験でない and 口が絡む行為を行っていない and キスができない態勢ではない
-	;TODO:口が絡む行為であることがすべてのコマンドごとにべた書きで口が絡む行為を羅列しているように見える、口が絡む行動が追加されたときに管理の手間が増えるため口が絡む行為を意味する関数を切り出しまとめて管理するべき
 	IF !TALENT:(MPLY:0):キス未経験 && !TALENT:(MTAR:0):キス未経験 && !IS_EQUIP_PLAYER(MPLY:0, 2, 11, 12, 20, 104) && !IS_EQUIP_PLAYER(MTAR:0, 2, 11, 12, 20, 104) && !IS_RIDDEN(MPLY:0) && !IS_RIDDEN(MTAR:0)
 		TFLAG:17 = 1
 
@@ -263,7 +262,6 @@ FOR LOCAL:0, 0, MEQUIP_TARGET_NUM:(ARG:0)
 	;1-1のときのみキスを追加
 	IF MPLY_NUM == 1 && MTAR_NUM == 1
 		;どちらもキス未経験でない and 口が絡む行為を行っていない and キスができない態勢ではない
-		;TODO:口が絡む行為であることがすべてのコマンドごとにべた書きで口が絡む行為を羅列しているように見える、口が絡む行動が追加されたときに管理の手間が増えるため口が絡む行為を意味する関数を切り出しまとめて管理するべき
 		IF !TALENT:(LOCAL:3):キス未経験 && !TALENT:(LOCAL:2):キス未経験 && !IS_EQUIP_PLAYER(LOCAL:3, 2, 11, 12, 20, 104) && !IS_EQUIP_PLAYER(LOCAL:2, 2, 11, 12, 20, 104) && !IS_RIDDEN(LOCAL:3) && !IS_RIDDEN(LOCAL:2)
 			TFLAG:17 = 1
 

--- a/ERB/TRAIN/COMF/COMF0_愛撫.ERB
+++ b/ERB/TRAIN/COMF/COMF0_愛撫.ERB
@@ -153,8 +153,8 @@ NEXT
 
 ;1-1のときのみキスを追加
 IF MPLY_NUM == 1 && MTAR_NUM == 1
-	;ターゲットに口の汚れがあって汚れ無視がない or 口が使用中 or キス未経験ならキスしない
-	;IF (!GET_STAIN(LOCAL:1, "口", "Ｐ", "精", "Ａ") || TALENT:(MPLY:0):汚れ無視) && !TALENT:(MPLY:0):キス未経験 && !TALENT:(MTAR:0):キス未経験
+	;どちらもキス未経験でない and 口が絡む行為を行っていない and キスができない態勢ではない
+	;TODO:口が絡む行為であることがすべてのコマンドごとにべた書きで口が絡む行為を羅列しているように見える、口が絡む行動が追加されたときに管理の手間が増えるため口が絡む行為を意味する関数を切り出しまとめて管理するべき
 	IF !TALENT:(MPLY:0):キス未経験 && !TALENT:(MTAR:0):キス未経験 && !IS_EQUIP_PLAYER(MPLY:0, 2, 11, 12, 20, 104) && !IS_EQUIP_PLAYER(MTAR:0, 2, 11, 12, 20, 104) && !IS_RIDDEN(MPLY:0) && !IS_RIDDEN(MTAR:0)
 		TFLAG:17 = 1
 
@@ -168,10 +168,6 @@ IF MPLY_NUM == 1 && MTAR_NUM == 1
 
 		TIMES SOURCE:(MPLY:0):愛情, 2.00
 		TIMES SOURCE:(MTAR:0):愛情, 2.00
-
-		;奴隷の口⇔調教者の口の汚れが移動
-		STAIN:(MPLY:0):0 |= STAIN:(MTAR:0):0
-		STAIN:(MTAR:0):0 |= STAIN:(MPLY:0):0
 	ENDIF
 ENDIF
 
@@ -266,8 +262,8 @@ FOR LOCAL:0, 0, MEQUIP_TARGET_NUM:(ARG:0)
 
 	;1-1のときのみキスを追加
 	IF MPLY_NUM == 1 && MTAR_NUM == 1
-		;ターゲットに口の汚れがあって汚れ無視がない or 口が使用中 or キス未経験ならキスしない
-		;IF (!GET_STAIN(LOCAL:1, "口", "Ｐ", "精", "Ａ") || TALENT:(MPLY:0):汚れ無視) && !TALENT:(MPLY:0):キス未経験 && !TALENT:(MTAR:0):キス未経験
+		;どちらもキス未経験でない and 口が絡む行為を行っていない and キスができない態勢ではない
+		;TODO:口が絡む行為であることがすべてのコマンドごとにべた書きで口が絡む行為を羅列しているように見える、口が絡む行動が追加されたときに管理の手間が増えるため口が絡む行為を意味する関数を切り出しまとめて管理するべき
 		IF !TALENT:(LOCAL:3):キス未経験 && !TALENT:(LOCAL:2):キス未経験 && !IS_EQUIP_PLAYER(LOCAL:3, 2, 11, 12, 20, 104) && !IS_EQUIP_PLAYER(LOCAL:2, 2, 11, 12, 20, 104) && !IS_RIDDEN(LOCAL:3) && !IS_RIDDEN(LOCAL:2)
 			TFLAG:17 = 1
 
@@ -281,10 +277,6 @@ FOR LOCAL:0, 0, MEQUIP_TARGET_NUM:(ARG:0)
 
 			TIMES SOURCE:(LOCAL:3):愛情, 2.00
 			TIMES SOURCE:(LOCAL:2):愛情, 2.00
-
-			;奴隷の口⇔調教者の口の汚れが移動
-			STAIN:(LOCAL:3):0 |= STAIN:(LOCAL:2):0
-			STAIN:(LOCAL:2):0 |= STAIN:(LOCAL:3):0
 		ENDIF
 	ENDIF
 

--- a/ERB/TRAIN/COMF/COMF101_顔面騎乗.ERB
+++ b/ERB/TRAIN/COMF/COMF101_顔面騎乗.ERB
@@ -141,10 +141,6 @@ IF MPLY_NUM == 1
 	IF TALENT:(MTAR:0):舌使い
 		TIMES SOURCE:(MPLY:0):快Ｃ, 1.50
 	ENDIF
-
-	;プレイヤーのＶ⇔ターゲットの口の汚れが移動
-	STAIN:(MTAR:0):3 |= STAIN:(MPLY:0):0
-	STAIN:(MPLY:0):0 |= STAIN:(MTAR:0):3
 ENDIF
 
 ;奉仕経験値を得られるコマンドのフラグ

--- a/ERB/TRAIN/COMF/COMF102_Ａ顔面騎乗.ERB
+++ b/ERB/TRAIN/COMF/COMF102_Ａ顔面騎乗.ERB
@@ -130,10 +130,6 @@ IF TALENT:(MTAR:0):舌使い
 	TIMES SOURCE:(MPLY:0):快Ａ, 1.50
 ENDIF
 
-;プレイヤーのＡ⇔ターゲットの口の汚れが移動
-;STAIN:(MTAR:0):3 |= STAIN:(MPLY:0):0
-;STAIN:(MPLY:0):0 |= STAIN:(MTAR:0):3
-
 ;奉仕経験値を得られるコマンドのフラグ
 TCVAR:(MTAR:0):4 = 1
 

--- a/ERB/TRAIN/COMF/COMF10_手コキ.ERB
+++ b/ERB/TRAIN/COMF/COMF10_手コキ.ERB
@@ -157,16 +157,6 @@ FOR LOCAL:0, 0, MPLY_NUM
 		;射精箇所と対象をセット
 		CALL STACK_SPERM(LOCAL:3, LOCAL:2, 射精部位_手)
 	NEXT
-
-	;奴隷の指⇔調教者のＰの汚れが移動
-	;IF HAS_PENIS(PLAYER)
-	;	STAIN:(LOCAL:1):1 |= STAIN:PLAYER:2
-	;	STAIN:PLAYER:2 |= STAIN:(LOCAL:1):1
-	;奴隷の指⇔調教者のＶの汚れが移動
-	;ELSE
-	;	STAIN:(LOCAL:1):3 |= STAIN:PLAYER:2
-	;	STAIN:PLAYER:2 |= STAIN:(LOCAL:1):3
-	;ENDIF
 NEXT
 
 ;●全ターゲットについて判定
@@ -321,35 +311,6 @@ ENDIF
 IF TALENT:(ARG:0):男嫌い
 	CALL COM_ORDER_ELEMENT(ARG:0, "男嫌い", -7)
 ENDIF
-
-;汚れの判定
-;IF !TALENT:(ARG:0):汚れ無視
-;	LOCAL:0 = 0
-;	;愛液の汚れ
-;	SIF STAIN:PLAYER:2 & 1
-;		LOCAL:0 += 1
-;	;精液の汚れ
-;	SIF STAIN:PLAYER:2 & 4
-;		LOCAL:0 += 3
-;	;アナルの汚れ
-;	SIF STAIN:PLAYER:2 & 8
-;		LOCAL:0 += 7
-;	SIF STAIN:PLAYER:2 & 16
-;		LOCAL:0 += 15
-;
-;	SIF TALENT:(ARG:0):汚臭鈍感
-;		LOCAL:0 /= 3
-;	SIF TALENT:(ARG:0):汚臭敏感
-;		LOCAL:0 *= 2
-;
-;	;汚れの影響が小さい
-;	LOCAL:0 /= 3
-;
-;	;汚れあり
-;	IF LOCAL:0 > 0
-;		CALL COM_ORDER_ELEMENT(ARG:0, "汚れあり", -LOCAL:0)
-;	ENDIF
-;ENDIF
 
 ;合意
 IF !TALENT:(ARG:0):合意 && !TALENT:(ARG:0):親友

--- a/ERB/TRAIN/COMF/COMF11_フェラチオ.ERB
+++ b/ERB/TRAIN/COMF/COMF11_フェラチオ.ERB
@@ -271,21 +271,6 @@ FOR LOCAL:0, 0, MPLY_NUM
 	ELSE
 		CALL KISS_COMMON(LOCAL:2, @"%ANAME(MTAR:0)%たちのペニス", (GET_SITUATION_BY_TRAIN_MODE() == "和姦" ? "乱交" # "輪姦"))
 	ENDIF
-
-	;奉仕精神ＬＶ２以上、性技ＬＶ２以上なら汚れをなめ取る
-	;IF ABL:(LOCAL:1):奉仕 >= 2 && ABL:(LOCAL:1):性技 >= 2
-	;	STAIN:PLAYER:2 = 2
-	;ENDIF
-
-	;奴隷の指⇔調教者のＰの汚れが移動
-	;IF HAS_PENIS(PLAYER)
-	;	STAIN:(LOCAL:1):1 |= STAIN:PLAYER:2
-	;	STAIN:PLAYER:2 |= STAIN:(LOCAL:1):1
-	;奴隷の指⇔調教者のＶの汚れが移動
-	;ELSE
-	;	STAIN:(LOCAL:1):3 |= STAIN:PLAYER:2
-	;	STAIN:PLAYER:2 |= STAIN:(LOCAL:1):3
-	;ENDIF
 NEXT
 
 ;●全ターゲットについて判定
@@ -442,31 +427,6 @@ IF TALENT:(ARG:0):キス未経験
 		CALL COM_ORDER_ELEMENT(ARG:0, "キス未経験", -10)
 	ENDIF
 ENDIF
-;汚れの判定
-;IF !TALENT:(ARG:0):汚れ無視
-;	LOCAL:0 = 0
-;	;愛液の汚れ
-;	SIF STAIN:PLAYER:2 & 1
-;		LOCAL:0 += 1
-;	;精液の汚れ
-;	SIF STAIN:PLAYER:2 & 4
-;		LOCAL:0 += 3
-;	;アナルの汚れ
-;	SIF STAIN:PLAYER:2 & 8
-;		LOCAL:0 += 7
-;	SIF STAIN:PLAYER:2 & 16
-;		LOCAL:0 += 15
-;
-;	SIF TALENT:(ARG:0):汚臭鈍感
-;		LOCAL:0 /= 3
-;	SIF TALENT:(ARG:0):汚臭敏感
-;		LOCAL:0 *= 2
-;
-;	;汚れあり
-;	IF LOCAL:0 > 0
-;		CALL COM_ORDER_ELEMENT(ARG:0, "汚れあり", -LOCAL:0)
-;	ENDIF
-;ENDIF
 
 ;合意
 IF !TALENT:(ARG:0):合意 && !TALENT:(ARG:0):親友

--- a/ERB/TRAIN/COMF/COMF12_パイズリ.ERB
+++ b/ERB/TRAIN/COMF/COMF12_パイズリ.ERB
@@ -239,19 +239,6 @@ FOR LOCAL:0, 0, MTAR_NUM
 	CALL ADD_SOURCE_INITIATIVE_U(LOCAL:1, 150, 80)
 NEXT
 
-	;奴隷の口⇔調教者のＰの汚れが移動
-	;STAIN:(LOCAL:1):0 |= STAIN:PLAYER:2
-	;STAIN:PLAYER:2 |= STAIN:(LOCAL:1):0
-
-	;奉仕精神ＬＶ２以上、性技ＬＶ２以上なら汚れをなめ取る
-	;IF ABL:(LOCAL:1):奉仕 >= 2 && ABL:(LOCAL:1):性技 >= 2
-	;	STAIN:PLAYER:2 = 2
-	;ENDIF
-
-	;奴隷のＢ⇔調教者のＰの汚れが移動
-	;STAIN:(LOCAL:1):5 |= STAIN:PLAYER:2
-	;STAIN:PLAYER:2 |= STAIN:(LOCAL:1):5
-
 ;主導度変化基準値
 TFLAG:49 = 2
 
@@ -397,33 +384,6 @@ ENDIF
 IF TALENT:(ARG:0):男嫌い
 	CALL COM_ORDER_ELEMENT(ARG:0, "男嫌い", -12)
 ENDIF
-
-
-;汚れの判定
-;IF !TALENT:(ARG:0):汚れ無視
-;	LOCAL:0 = 0
-;	;愛液の汚れ
-;	SIF STAIN:PLAYER:2 & 1
-;		LOCAL:0 += 1
-;	;精液の汚れ
-;	SIF STAIN:PLAYER:2 & 4
-;		LOCAL:0 += 3
-;	;アナルの汚れ
-;	SIF STAIN:PLAYER:2 & 8
-;		LOCAL:0 += 7
-;	SIF STAIN:PLAYER:2 & 16
-;		LOCAL:0 += 15
-;
-;	SIF TALENT:(ARG:0):汚臭鈍感
-;		LOCAL:0 /= 3
-;	SIF TALENT:(ARG:0):汚臭敏感
-;		LOCAL:0 *= 2
-;
-;	;汚れあり
-;	IF LOCAL:0 > 0
-;		CALL COM_ORDER_ELEMENT(ARG:0, "汚れあり", -LOCAL:0)
-;	ENDIF
-;ENDIF
 
 ;合意
 IF !TALENT:(ARG:0):合意 && !TALENT:(ARG:0):親友

--- a/ERB/TRAIN/COMF/COMF13_素股.ERB
+++ b/ERB/TRAIN/COMF/COMF13_素股.ERB
@@ -162,10 +162,6 @@ SOURCE:(MTAR:0):性行動 = 180
 ;主導権に応じた優越・受動のソース追加
 CALL ADD_SOURCE_INITIATIVE_U(MTAR:0, 130, 50)
 
-;奴隷のＶ⇔調教者のＰの汚れが移動
-;STAIN:(MTAR:0):3 |= STAIN:PLAYER:2
-;STAIN:PLAYER:2 |= STAIN:(MTAR:0):3
-
 ;奉仕経験値を得られるコマンドのフラグ
 TCVAR:(MTAR:0):4 = 1
 
@@ -286,36 +282,6 @@ ENDIF
 IF TFLAG:69
 	CALL COM_ORDER_ELEMENT(ARG:0, "桃源香", 3)
 ENDIF
-
-
-;汚れの判定
-;IF !TALENT:(ARG:0):汚れ無視
-;	LOCAL:0 = 0
-;	;愛液の汚れ
-;	SIF STAIN:PLAYER:2 & 1
-;		LOCAL:0 += 1
-;	;精液の汚れ
-;	SIF STAIN:PLAYER:2 & 4
-;		LOCAL:0 += 3
-;	;アナルの汚れ
-;	SIF STAIN:PLAYER:2 & 8
-;		LOCAL:0 += 7
-;	SIF STAIN:PLAYER:2 & 16
-;		LOCAL:0 += 15
-;
-;	SIF TALENT:(ARG:0):汚臭鈍感
-;		LOCAL:0 /= 3
-;	SIF TALENT:(ARG:0):汚臭敏感
-;		LOCAL:0 *= 2
-;
-;	;汚れの影響が小さい
-;	LOCAL:0 /= 3
-;
-;	;汚れあり
-;	IF LOCAL:0 > 0
-;		CALL COM_ORDER_ELEMENT(ARG:0, "汚れあり", -LOCAL:0)
-;	ENDIF
-;ENDIF
 
 ;合意
 IF !TALENT:(ARG:0):合意 && !TALENT:(ARG:0):親友

--- a/ERB/TRAIN/COMF/COMF160_立ちバック.ERB
+++ b/ERB/TRAIN/COMF/COMF160_立ちバック.ERB
@@ -195,10 +195,6 @@ CALL ADD_SOURCE_INITIATIVE_U(MTAR:0, 120, 180)
 ;奉仕経験値を得られるコマンドのフラグ
 TCVAR:(MTAR:0):4 = 1
 
-;奴隷のＶ⇔調教者のＰの汚れが移動
-STAIN:(MTAR:0):3 |= STAIN:(MPLY:0):2
-STAIN:(MPLY:0):2 |= STAIN:(MTAR:0):3
-
 ;体位フラグのセット
 TCVAR:(MPLY:0):31 = 2
 TCVAR:(MTAR:0):33 = 2

--- a/ERB/TRAIN/COMF/COMF161_Ａ立ちバック.ERB
+++ b/ERB/TRAIN/COMF/COMF161_Ａ立ちバック.ERB
@@ -193,10 +193,6 @@ CALL ADD_SOURCE_INITIATIVE_U(MTAR:0, 120, 180)
 ;奉仕経験値を得られるコマンドのフラグ
 TCVAR:(MTAR:0):4 = 1
 
-;奴隷のＶ⇔調教者のＰの汚れが移動
-STAIN:(MTAR:0):3 |= STAIN:(MPLY:0):2
-STAIN:(MPLY:0):2 |= STAIN:(MTAR:0):3
-
 ;体位フラグのセット
 TCVAR:(MPLY:0):31 = 2
 TCVAR:(MTAR:0):35 = 2

--- a/ERB/TRAIN/COMF/COMF16_オナホコキ.ERB
+++ b/ERB/TRAIN/COMF/COMF16_オナホコキ.ERB
@@ -227,35 +227,6 @@ IF TALENT:(ARG:0):男嫌い
 	CALL COM_ORDER_ELEMENT(ARG:0, "男嫌い", -7)
 ENDIF
 
-;汚れの判定
-;IF !TALENT:(ARG:0):汚れ無視
-;	LOCAL:0 = 0
-;	;愛液の汚れ
-;	SIF STAIN:PLAYER:2 & 1
-;		LOCAL:0 += 1
-;	;精液の汚れ
-;	SIF STAIN:PLAYER:2 & 4
-;		LOCAL:0 += 3
-;	;アナルの汚れ
-;	SIF STAIN:PLAYER:2 & 8
-;		LOCAL:0 += 7
-;	SIF STAIN:PLAYER:2 & 16
-;		LOCAL:0 += 15
-;
-;	SIF TALENT:(ARG:0):汚臭鈍感
-;		LOCAL:0 /= 3
-;	SIF TALENT:(ARG:0):汚臭敏感
-;		LOCAL:0 *= 2
-;
-;	;汚れの影響が小さい
-;	LOCAL:0 /= 3
-;
-;	;汚れあり
-;	IF LOCAL:0 > 0
-;		CALL COM_ORDER_ELEMENT(ARG:0, "汚れあり", -LOCAL:0)
-;	ENDIF
-;ENDIF
-
 ;合意
 IF !TALENT:(ARG:0):合意 && !TALENT:(ARG:0):親友
 	CALL COM_ORDER_ELEMENT(ARG:0, "合意なし", -10)

--- a/ERB/TRAIN/COMF/COMF17_尻尾コキ.ERB
+++ b/ERB/TRAIN/COMF/COMF17_尻尾コキ.ERB
@@ -263,35 +263,6 @@ IF TALENT:(ARG:0):男嫌い
 	CALL COM_ORDER_ELEMENT(ARG:0, "男嫌い", -7)
 ENDIF
 
-;汚れの判定
-;IF !TALENT:(ARG:0):汚れ無視
-;	LOCAL:0 = 0
-;	;愛液の汚れ
-;	SIF STAIN:PLAYER:2 & 1
-;		LOCAL:0 += 1
-;	;精液の汚れ
-;	SIF STAIN:PLAYER:2 & 4
-;		LOCAL:0 += 3
-;	;アナルの汚れ
-;	SIF STAIN:PLAYER:2 & 8
-;		LOCAL:0 += 7
-;	SIF STAIN:PLAYER:2 & 16
-;		LOCAL:0 += 15
-;
-;	SIF TALENT:(ARG:0):汚臭鈍感
-;		LOCAL:0 /= 3
-;	SIF TALENT:(ARG:0):汚臭敏感
-;		LOCAL:0 *= 2
-;
-;	;汚れの影響が小さい
-;	LOCAL:0 /= 3
-;
-;	;汚れあり
-;	IF LOCAL:0 > 0
-;		CALL COM_ORDER_ELEMENT(ARG:0, "汚れあり", -LOCAL:0)
-;	ENDIF
-;ENDIF
-
 ;合意
 IF !TALENT:(ARG:0):合意 && !TALENT:(ARG:0):親友
 	CALL COM_ORDER_ELEMENT(ARG:0, "合意なし", -10)

--- a/ERB/TRAIN/COMF/COMF18_髪コキ.ERB
+++ b/ERB/TRAIN/COMF/COMF18_髪コキ.ERB
@@ -219,35 +219,6 @@ IF TALENT:(ARG:0):男嫌い
 	CALL COM_ORDER_ELEMENT(ARG:0, "男嫌い", -7)
 ENDIF
 
-;汚れの判定
-;IF !TALENT:(ARG:0):汚れ無視
-;	LOCAL:0 = 0
-;	;愛液の汚れ
-;	SIF STAIN:PLAYER:2 & 1
-;		LOCAL:0 += 1
-;	;精液の汚れ
-;	SIF STAIN:PLAYER:2 & 4
-;		LOCAL:0 += 3
-;	;アナルの汚れ
-;	SIF STAIN:PLAYER:2 & 8
-;		LOCAL:0 += 7
-;	SIF STAIN:PLAYER:2 & 18
-;		LOCAL:0 += 15
-;
-;	SIF TALENT:(ARG:0):汚臭鈍感
-;		LOCAL:0 /= 3
-;	SIF TALENT:(ARG:0):汚臭敏感
-;		LOCAL:0 *= 2
-;
-;	;汚れの影響が小さい
-;	LOCAL:0 /= 3
-;
-;	;汚れあり
-;	IF LOCAL:0 > 0
-;		CALL COM_ORDER_ELEMENT(ARG:0, "汚れあり", -LOCAL:0)
-;	ENDIF
-;ENDIF
-
 ;合意
 IF !TALENT:(ARG:0):合意 && !TALENT:(ARG:0):親友
 	CALL COM_ORDER_ELEMENT(ARG:0, "合意なし", -10)

--- a/ERB/TRAIN/COMF/COMF19_玉舐め.ERB
+++ b/ERB/TRAIN/COMF/COMF19_玉舐め.ERB
@@ -206,20 +206,6 @@ FOR LOCAL:0, 0, MPLY_NUM
 	ELSE
 		CALL KISS_COMMON(LOCAL:2, @"%ANAME(MTAR:0)%たちの睾丸", (GET_SITUATION_BY_TRAIN_MODE() == "和姦" ? "乱交" # "輪姦"))
 	ENDIF
-	;奉仕精神ＬＶ２以上、性技ＬＶ２以上なら汚れをなめ取る
-	;IF ABL:(LOCAL:1):奉仕 >= 2 && ABL:(LOCAL:1):性技 >= 2
-	;	STAIN:PLAYER:2 = 2
-	;ENDIF
-
-	;奴隷の指⇔調教者のＰの汚れが移動
-	;IF HAS_PENIS(PLAYER)
-	;	STAIN:(LOCAL:1):1 |= STAIN:PLAYER:2
-	;	STAIN:PLAYER:2 |= STAIN:(LOCAL:1):1
-	;奴隷の指⇔調教者のＶの汚れが移動
-	;ELSE
-	;	STAIN:(LOCAL:1):3 |= STAIN:PLAYER:2
-	;	STAIN:PLAYER:2 |= STAIN:(LOCAL:1):3
-	;ENDIF
 NEXT
 
 ;●全ターゲットについて判定
@@ -376,31 +362,6 @@ IF TALENT:(ARG:0):キス未経験
 		CALL COM_ORDER_ELEMENT(ARG:0, "キス未経験", -10)
 	ENDIF
 ENDIF
-;汚れの判定
-;IF !TALENT:(ARG:0):汚れ無視
-;	LOCAL:0 = 0
-;	;愛液の汚れ
-;	SIF STAIN:PLAYER:2 & 1
-;		LOCAL:0 += 1
-;	;精液の汚れ
-;	SIF STAIN:PLAYER:2 & 4
-;		LOCAL:0 += 3
-;	;アナルの汚れ
-;	SIF STAIN:PLAYER:2 & 8
-;		LOCAL:0 += 7
-;	SIF STAIN:PLAYER:2 & 16
-;		LOCAL:0 += 15
-;
-;	SIF TALENT:(ARG:0):汚臭鈍感
-;		LOCAL:0 /= 3
-;	SIF TALENT:(ARG:0):汚臭敏感
-;		LOCAL:0 *= 2
-;
-;	;汚れあり
-;	IF LOCAL:0 > 0
-;		CALL COM_ORDER_ELEMENT(ARG:0, "汚れあり", -LOCAL:0)
-;	ENDIF
-;ENDIF
 
 ;合意
 IF !TALENT:(ARG:0):合意 && !TALENT:(ARG:0):親友

--- a/ERB/TRAIN/COMF/COMF1_胸愛撫.ERB
+++ b/ERB/TRAIN/COMF/COMF1_胸愛撫.ERB
@@ -140,10 +140,6 @@ FOR LOCAL:0, 0, MTAR_NUM
 	SOURCE:(LOCAL:1):接触 = 60
 	SOURCE:(LOCAL:1):性行動 = 180
 
-	;奴隷のＢ⇔調教者の指の汚れが移動
-	;STAIN:(LOCAL:1):5 |= STAIN:PLAYER:1
-	;STAIN:PLAYER:1 |= STAIN:(LOCAL:1):5
-
 	;主導権に応じた優越・屈従のソース追加
 	CALL ADD_SOURCE_INITIATIVE_U(LOCAL:1, 80, 0)
 

--- a/ERB/TRAIN/COMF/COMF20_キス.ERB
+++ b/ERB/TRAIN/COMF/COMF20_キス.ERB
@@ -192,10 +192,6 @@ FOR LOCAL:0, 0, MTAR_NUM
 	NEXT
 NEXT
 
-;奴隷の口⇔調教者の口の汚れが移動
-;STAIN:(LOCAL:1):0 |= STAIN:MASTER:0
-;STAIN:MASTER:0 |= STAIN:(LOCAL:1):0
-
 ;主導度変化基準値
 TFLAG:49 = 2
 
@@ -393,35 +389,6 @@ IF TALENT:(ARG:0):キス未経験
 		CALL COM_ORDER_ELEMENT(ARG:0, "キス未経験", -30)
 	ENDIF
 ENDIF
-
-;汚れの判定
-;IF !TALENT:(ARG:0):汚れ無視
-;	LOCAL:0 = 0
-	;愛液の汚れ
-;	SIF STAIN:PLAYER:2 & 1
-;		LOCAL:0 += 1
-	;精液の汚れ
-;	SIF STAIN:PLAYER:2 & 4
-;		LOCAL:0 += 3
-	;アナルの汚れ
-;	SIF STAIN:PLAYER:2 & 8
-;		LOCAL:0 += 7
-;	SIF STAIN:PLAYER:2 & 16
-;		LOCAL:0 += 15
-
-;	SIF TALENT:(ARG:0):汚臭鈍感
-;		LOCAL:0 /= 3
-;	SIF TALENT:(ARG:0):汚臭敏感
-;		LOCAL:0 *= 2
-
-	;汚れの影響がやや小さい
-;	LOCAL:0 /= 2
-
-	;汚れあり
-;	IF LOCAL:0 > 0
-;		CALL COM_ORDER_ELEMENT(ARG:0, "汚れあり", -LOCAL:0)
-;	ENDIF
-;ENDIF
 
 ;合意
 IF !TALENT:(ARG:0):合意 && !TALENT:(ARG:0):親友

--- a/ERB/TRAIN/COMF/COMF2_クンニ.ERB
+++ b/ERB/TRAIN/COMF/COMF2_クンニ.ERB
@@ -50,9 +50,6 @@ SIF !IS_PLAYABLE(MPLY:0)
 ;挿入中は不可
 SIF IS_INSERT_MUTUAL(MPLY:0, MTAR:0)
 	RETURN 0
-;性器に愛液、母乳以外の汚れがあり、実行者に汚れ無視がない場合不可
-;SIF (STAIN:(MTAR:0):3 & 14) && !TALENT:(MPLY:0):汚れ無視
-;	RETURN 0
 ;プレイヤーとターゲットが共に拘束中なら不可
 SIF IS_BIND(MPLY:0) && IS_BIND(MTAR:0)
 	RETURN 0
@@ -143,10 +140,6 @@ CALL ADD_SOURCE_INITIATIVE_U(MTAR:0, 150, 0)
 IF TALENT:(MPLY:0):舌使い
 	TIMES SOURCE:(MTAR:0):快Ｃ, 1.50
 ENDIF
-
-;奴隷のＶ⇔調教者の口の汚れが移動
-STAIN:(MTAR:0):3 |= STAIN:(MPLY:0):0
-STAIN:(MPLY:0):0 |= STAIN:(MTAR:0):3
 
 ;射精箇所と対象をセット
 CALL STACK_SPERM(MTAR:0, MPLY:0, 8)

--- a/ERB/TRAIN/COMF/COMF30_正常位.ERB
+++ b/ERB/TRAIN/COMF/COMF30_正常位.ERB
@@ -200,10 +200,6 @@ CALL ADD_SOURCE_INITIATIVE_U(MTAR:0, 150, 100)
 ;奉仕経験値を得られるコマンドのフラグ
 TCVAR:(MTAR:0):4 = 1
 
-;奴隷のＶ⇔調教者のＰの汚れが移動
-STAIN:(MTAR:0):3 |= STAIN:(MPLY:0):2
-STAIN:(MPLY:0):2 |= STAIN:(MTAR:0):3
-
 ;体位フラグのセット
 TCVAR:(MPLY:0):31 = 1
 TCVAR:(MTAR:0):33 = 1

--- a/ERB/TRAIN/COMF/COMF31_後背位.ERB
+++ b/ERB/TRAIN/COMF/COMF31_後背位.ERB
@@ -200,10 +200,6 @@ CALL ADD_SOURCE_INITIATIVE_U(MTAR:0, 120, 180)
 ;奉仕経験値を得られるコマンドのフラグ
 TCVAR:(MTAR:0):4 = 1
 
-;奴隷のＶ⇔調教者のＰの汚れが移動
-STAIN:(MTAR:0):3 |= STAIN:(MPLY:0):2
-STAIN:(MPLY:0):2 |= STAIN:(MTAR:0):3
-
 ;体位フラグのセット
 TCVAR:(MPLY:0):31 = 2
 TCVAR:(MTAR:0):33 = 2

--- a/ERB/TRAIN/COMF/COMF32_対面座位.ERB
+++ b/ERB/TRAIN/COMF/COMF32_対面座位.ERB
@@ -231,10 +231,6 @@ CALL ADD_SOURCE_INITIATIVE_U(MTAR:0, 150, 100)
 ;奉仕経験値を得られるコマンドのフラグ
 TCVAR:(MTAR:0):4 = 1
 
-;奴隷のＶ⇔調教者のＰの汚れが移動
-STAIN:(MTAR:0):3 |= STAIN:(MPLY:0):2
-STAIN:(MPLY:0):2 |= STAIN:(MTAR:0):3
-
 ;射精箇所と対象をセット(ターゲット側)
 CALL STACK_SPERM(MTAR:0, MPLY:0, 0)
 

--- a/ERB/TRAIN/COMF/COMF33_背面座位.ERB
+++ b/ERB/TRAIN/COMF/COMF33_背面座位.ERB
@@ -207,10 +207,6 @@ CALL ADD_SOURCE_INITIATIVE_U(MTAR:0, 120, 180)
 ;奉仕経験値を得られるコマンドのフラグ
 TCVAR:(MTAR:0):4 = 1
 
-;奴隷のＶ⇔調教者のＰの汚れが移動
-STAIN:(MTAR:0):3 |= STAIN:(MPLY:0):2
-STAIN:(MPLY:0):2 |= STAIN:(MTAR:0):3
-
 ;体位フラグのセット
 TCVAR:(MPLY:0):31 = 4
 TCVAR:(MTAR:0):33 = 4

--- a/ERB/TRAIN/COMF/COMF34_騎乗位.ERB
+++ b/ERB/TRAIN/COMF/COMF34_騎乗位.ERB
@@ -192,10 +192,6 @@ CALL ADD_SOURCE_INITIATIVE_U(MTAR:0, 200, 150)
 ;奉仕経験値を得られるコマンドのフラグ
 TCVAR:(MTAR:0):4 = 1
 
-;奴隷のＶ⇔調教者のＰの汚れが移動
-STAIN:(MTAR:0):3 |= STAIN:(MPLY:0):2
-STAIN:(MPLY:0):2 |= STAIN:(MTAR:0):3
-
 ;射精箇所と対象をセット(ターゲット側)
 CALL STACK_SPERM(MTAR:0, MPLY:0, 0)
 

--- a/ERB/TRAIN/COMF/COMF35_背面騎乗位.ERB
+++ b/ERB/TRAIN/COMF/COMF35_背面騎乗位.ERB
@@ -194,10 +194,6 @@ CALL ADD_SOURCE_INITIATIVE_U(MTAR:0, 200, 150)
 ;奉仕経験値を得られるコマンドのフラグ
 TCVAR:(MTAR:0):4 = 1
 
-;奴隷のＶ⇔調教者のＰの汚れが移動
-STAIN:(MTAR:0):3 |= STAIN:(MPLY:0):2
-STAIN:(MPLY:0):2 |= STAIN:(MTAR:0):3
-
 ;射精箇所と対象をセット(ターゲット側)
 CALL STACK_SPERM(MTAR:0, MPLY:0, 0)
 

--- a/ERB/TRAIN/COMF/COMF36_二本挿入.ERB
+++ b/ERB/TRAIN/COMF/COMF36_二本挿入.ERB
@@ -162,9 +162,6 @@ CALL COM_COMMON_SEX_V(MTAR:0, LOCAL:3)
 CALL ADD_SOURCE_INITIATIVE_U(MTAR:0, 150, 100)
 	;奉仕経験値を得られるコマンドのフラグ
 TCVAR:(MTAR:0):4 = 1
-;ターゲットのＶ⇔プレイヤーのＰの汚れが移動
-;STAIN:(LOCAL:2):3 |= STAIN:(MPLY:0):2
-;STAIN:(MPLY:0):2 |= STAIN:(LOCAL:2):3
 
 ;主導度変化基準値
 TFLAG:49 = 3
@@ -245,10 +242,6 @@ NEXT
 
 	;奉仕経験値を得られるコマンドのフラグ
 	TCVAR:(LOCAL:2):4 = 1
-
-	;ターゲットのＶ⇔プレイヤーのＰの汚れが移動
-	;STAIN:(LOCAL:2):3 |= STAIN:(MPLY:0):2
-	;STAIN:(MPLY:0):2 |= STAIN:(LOCAL:2):3
 
 RETURN 1
 

--- a/ERB/TRAIN/COMF/COMF37_側位.ERB
+++ b/ERB/TRAIN/COMF/COMF37_側位.ERB
@@ -202,10 +202,6 @@ CALL ADD_SOURCE_INITIATIVE_U(MTAR:0, 120, 180)
 ;奉仕経験値を得られるコマンドのフラグ
 TCVAR:(MTAR:0):4 = 1
 
-;奴隷のＶ⇔調教者のＰの汚れが移動
-STAIN:(MTAR:0):3 |= STAIN:(MPLY:0):2
-STAIN:(MPLY:0):2 |= STAIN:(MTAR:0):3
-
 ;体位フラグのセット
 TCVAR:(MPLY:0):37 = 2
 TCVAR:(MTAR:0):33 = 2

--- a/ERB/TRAIN/COMF/COMF38_屈曲位.ERB
+++ b/ERB/TRAIN/COMF/COMF38_屈曲位.ERB
@@ -186,10 +186,6 @@ CALL ADD_SOURCE_INITIATIVE_U(MTAR:0, 150, 100)
 ;奉仕経験値を得られるコマンドのフラグ
 TCVAR:(MTAR:0):4 = 1
 
-;奴隷のＶ⇔調教者のＰの汚れが移動
-STAIN:(MTAR:0):3 |= STAIN:(MPLY:0):2
-STAIN:(MPLY:0):2 |= STAIN:(MTAR:0):3
-
 ;体位フラグのセット
 TCVAR:(MPLY:0):31 = 1
 TCVAR:(MTAR:0):33 = 1

--- a/ERB/TRAIN/COMF/COMF390_二人で出掛ける.ERB
+++ b/ERB/TRAIN/COMF/COMF390_二人で出掛ける.ERB
@@ -486,13 +486,6 @@ ELSEIF TFLAG:54 == 4
 
 ;温泉
 ELSEIF TFLAG:54 == 7
-	;毎ターン汚れリセット
-	STAIN:(ARG:0):0 = 0
-	STAIN:(ARG:0):1 = 0
-	STAIN:(ARG:0):2 = 2
-	STAIN:(ARG:0):3 = 1
-	STAIN:(ARG:0):4 = 8
-	STAIN:(ARG:0):5 = 0
 
 	;ウフフ中
 	IF FLAG:ウフフフラグ

--- a/ERB/TRAIN/COMF/COMF39_駅弁.ERB
+++ b/ERB/TRAIN/COMF/COMF39_駅弁.ERB
@@ -185,10 +185,6 @@ CALL ADD_SOURCE_INITIATIVE_U(MTAR:0, 150, 100)
 ;奉仕経験値を得られるコマンドのフラグ
 TCVAR:(MTAR:0):4 = 1
 
-;奴隷のＶ⇔調教者のＰの汚れが移動
-STAIN:(MTAR:0):3 |= STAIN:(MPLY:0):2
-STAIN:(MPLY:0):2 |= STAIN:(MTAR:0):3
-
 ;体位フラグのセット
 TCVAR:(MPLY:0):31 = 1
 TCVAR:(MTAR:0):33 = 1

--- a/ERB/TRAIN/COMF/COMF40_Ａ正常位.ERB
+++ b/ERB/TRAIN/COMF/COMF40_Ａ正常位.ERB
@@ -195,10 +195,6 @@ CALL ADD_SOURCE_INITIATIVE_U(MTAR:0, 150, 100)
 ;奉仕経験値を得られるコマンドのフラグ
 TCVAR:(MTAR:0):4 = 1
 
-;奴隷のＶ⇔調教者のＰの汚れが移動
-STAIN:(MTAR:0):3 |= STAIN:(MPLY:0):2
-STAIN:(MPLY:0):2 |= STAIN:(MTAR:0):3
-
 ;射精箇所と対象をセット(ターゲット側)
 CALL STACK_SPERM(MTAR:0, MPLY:0, 0)
 

--- a/ERB/TRAIN/COMF/COMF41_Ａ後背位.ERB
+++ b/ERB/TRAIN/COMF/COMF41_Ａ後背位.ERB
@@ -199,10 +199,6 @@ CALL ADD_SOURCE_INITIATIVE_U(MTAR:0, 120, 180)
 ;奉仕経験値を得られるコマンドのフラグ
 TCVAR:(MTAR:0):4 = 1
 
-;奴隷のＶ⇔調教者のＰの汚れが移動
-STAIN:(MTAR:0):3 |= STAIN:(MPLY:0):2
-STAIN:(MPLY:0):2 |= STAIN:(MTAR:0):3
-
 ;体位フラグのセット
 TCVAR:(MPLY:0):31 = 2
 TCVAR:(MTAR:0):35 = 2

--- a/ERB/TRAIN/COMF/COMF42_Ａ対面座位.ERB
+++ b/ERB/TRAIN/COMF/COMF42_Ａ対面座位.ERB
@@ -226,10 +226,6 @@ CALL ADD_SOURCE_INITIATIVE_U(MTAR:0, 150, 100)
 ;奉仕経験値を得られるコマンドのフラグ
 TCVAR:(MTAR:0):4 = 1
 
-;奴隷のＶ⇔調教者のＰの汚れが移動
-STAIN:(MTAR:0):3 |= STAIN:(MPLY:0):2
-STAIN:(MPLY:0):2 |= STAIN:(MTAR:0):3
-
 ;射精箇所と対象をセット(ターゲット側)
 CALL STACK_SPERM(MTAR:0, MPLY:0, 0)
 

--- a/ERB/TRAIN/COMF/COMF43_Ａ背面座位.ERB
+++ b/ERB/TRAIN/COMF/COMF43_Ａ背面座位.ERB
@@ -203,10 +203,6 @@ CALL ADD_SOURCE_INITIATIVE_U(MTAR:0, 120, 180)
 ;奉仕経験値を得られるコマンドのフラグ
 TCVAR:(MTAR:0):4 = 1
 
-;奴隷のＶ⇔調教者のＰの汚れが移動
-STAIN:(MTAR:0):3 |= STAIN:(MPLY:0):2
-STAIN:(MPLY:0):2 |= STAIN:(MTAR:0):3
-
 ;体位フラグのセット
 TCVAR:(MPLY:0):31 = 4
 TCVAR:(MTAR:0):35 = 4

--- a/ERB/TRAIN/COMF/COMF44_Ａ騎乗位.ERB
+++ b/ERB/TRAIN/COMF/COMF44_Ａ騎乗位.ERB
@@ -187,10 +187,6 @@ CALL ADD_SOURCE_INITIATIVE_U(MTAR:0, 200, 150)
 ;奉仕経験値を得られるコマンドのフラグ
 TCVAR:(MTAR:0):4 = 1
 
-;奴隷のＶ⇔調教者のＰの汚れが移動
-STAIN:(MTAR:0):3 |= STAIN:(MPLY:0):2
-STAIN:(MPLY:0):2 |= STAIN:(MTAR:0):3
-
 ;射精箇所と対象をセット(ターゲット側)
 CALL STACK_SPERM(MTAR:0, MPLY:0, 0)
 

--- a/ERB/TRAIN/COMF/COMF45_Ａ背面騎乗位.ERB
+++ b/ERB/TRAIN/COMF/COMF45_Ａ背面騎乗位.ERB
@@ -193,10 +193,6 @@ CALL ADD_SOURCE_INITIATIVE_U(MTAR:0, 200, 150)
 ;奉仕経験値を得られるコマンドのフラグ
 TCVAR:(MTAR:0):4 = 1
 
-;奴隷のＶ⇔調教者のＰの汚れが移動
-STAIN:(MTAR:0):3 |= STAIN:(MPLY:0):2
-STAIN:(MPLY:0):2 |= STAIN:(MTAR:0):3
-
 ;射精箇所と対象をセット(ターゲット側)
 CALL STACK_SPERM(MTAR:0, MPLY:0, 0)
 

--- a/ERB/TRAIN/COMF/COMF46_Ａ二本挿入.ERB
+++ b/ERB/TRAIN/COMF/COMF46_Ａ二本挿入.ERB
@@ -152,9 +152,6 @@ CALL COM_COMMON_ASEX_A(MTAR:0, LOCAL:3)
 CALL ADD_SOURCE_INITIATIVE_U(MTAR:0, 150, 100)
 	;奉仕経験値を得られるコマンドのフラグ
 TCVAR:(MTAR:0):4 = 1
-;ターゲットのＶ⇔プレイヤーのＰの汚れが移動
-;STAIN:(LOCAL:2):3 |= STAIN:(MPLY:0):2
-;STAIN:(MPLY:0):2 |= STAIN:(LOCAL:2):3
 
 ;主導度変化基準値
 TFLAG:49 = 3
@@ -235,11 +232,6 @@ NEXT
 
 	;奉仕経験値を得られるコマンドのフラグ
 	TCVAR:(LOCAL:2):4 = 1
-
-	;ターゲットのＶ⇔プレイヤーのＰの汚れが移動
-	;STAIN:(LOCAL:2):3 |= STAIN:(MPLY:0):2
-	;STAIN:(MPLY:0):2 |= STAIN:(LOCAL:2):3
-
 RETURN 1
 
 ;-------------------------------------------------

--- a/ERB/TRAIN/COMF/COMF47_Ａ側位.ERB
+++ b/ERB/TRAIN/COMF/COMF47_Ａ側位.ERB
@@ -196,10 +196,6 @@ CALL ADD_SOURCE_INITIATIVE_U(MTAR:0, 120, 180)
 ;奉仕経験値を得られるコマンドのフラグ
 TCVAR:(MTAR:0):4 = 1
 
-;奴隷のＶ⇔調教者のＰの汚れが移動
-STAIN:(MTAR:0):3 |= STAIN:(MPLY:0):2
-STAIN:(MPLY:0):2 |= STAIN:(MTAR:0):3
-
 ;体位フラグのセット
 TCVAR:(MPLY:0):31 = 2
 TCVAR:(MTAR:0):35 = 2

--- a/ERB/TRAIN/COMF/COMF48_Ａ屈曲位.ERB
+++ b/ERB/TRAIN/COMF/COMF48_Ａ屈曲位.ERB
@@ -192,10 +192,6 @@ CALL ADD_SOURCE_INITIATIVE_U(MTAR:0, 150, 100)
 ;奉仕経験値を得られるコマンドのフラグ
 TCVAR:(MTAR:0):4 = 1
 
-;奴隷のＶ⇔調教者のＰの汚れが移動
-STAIN:(MTAR:0):3 |= STAIN:(MPLY:0):2
-STAIN:(MPLY:0):2 |= STAIN:(MTAR:0):3
-
 ;射精箇所と対象をセット(ターゲット側)
 CALL STACK_SPERM(MTAR:0, MPLY:0, 0)
 

--- a/ERB/TRAIN/COMF/COMF49_Ａ駅弁.ERB
+++ b/ERB/TRAIN/COMF/COMF49_Ａ駅弁.ERB
@@ -194,10 +194,6 @@ CALL ADD_SOURCE_INITIATIVE_U(MTAR:0, 150, 100)
 ;奉仕経験値を得られるコマンドのフラグ
 TCVAR:(MTAR:0):4 = 1
 
-;奴隷のＶ⇔調教者のＰの汚れが移動
-STAIN:(MTAR:0):3 |= STAIN:(MPLY:0):2
-STAIN:(MPLY:0):2 |= STAIN:(MTAR:0):3
-
 ;射精箇所と対象をセット(ターゲット側)
 CALL STACK_SPERM(MTAR:0, MPLY:0, 0)
 

--- a/ERB/TRAIN/COMF/COMF52_逆駅弁.ERB
+++ b/ERB/TRAIN/COMF/COMF52_逆駅弁.ERB
@@ -185,10 +185,6 @@ CALL ADD_SOURCE_INITIATIVE_U(MTAR:0, 150, 100)
 ;奉仕経験値を得られるコマンドのフラグ
 TCVAR:(MTAR:0):4 = 1
 
-;奴隷のＶ⇔調教者のＰの汚れが移動
-STAIN:(MTAR:0):3 |= STAIN:(MPLY:0):2
-STAIN:(MPLY:0):2 |= STAIN:(MTAR:0):3
-
 ;体位フラグのセット
 TCVAR:(MPLY:0):31 = 1
 TCVAR:(MTAR:0):33 = 1

--- a/ERB/TRAIN/COMF/COMF53_Ａ逆駅弁.ERB
+++ b/ERB/TRAIN/COMF/COMF53_Ａ逆駅弁.ERB
@@ -194,10 +194,6 @@ CALL ADD_SOURCE_INITIATIVE_U(MTAR:0, 150, 100)
 ;奉仕経験値を得られるコマンドのフラグ
 TCVAR:(MTAR:0):4 = 1
 
-;奴隷のＶ⇔調教者のＰの汚れが移動
-STAIN:(MTAR:0):3 |= STAIN:(MPLY:0):2
-STAIN:(MPLY:0):2 |= STAIN:(MTAR:0):3
-
 ;射精箇所と対象をセット(ターゲット側)
 CALL STACK_SPERM(MTAR:0, MPLY:0, 0)
 

--- a/ERB/TRAIN/COMF/COMF55_順番に挿入.ERB
+++ b/ERB/TRAIN/COMF/COMF55_順番に挿入.ERB
@@ -150,10 +150,6 @@ FOR LOCAL:0, 0, MTAR_NUM
 
 	;奉仕経験値を得られるコマンドのフラグ
 	TCVAR:(LOCAL:2):4 = 1
-
-	;ターゲットのＶ⇔プレイヤーのＰの汚れが移動
-	;STAIN:(LOCAL:2):3 |= STAIN:(MPLY:0):2
-	;STAIN:(MPLY:0):2 |= STAIN:(LOCAL:2):3
 NEXT
 
 
@@ -250,10 +246,6 @@ FOR LOCAL:1, 0,  MEQUIP_TARGET_NUM:(ARG:0)
 
 	;奉仕経験値を得られるコマンドのフラグ
 	TCVAR:(LOCAL:2):4 = 1
-
-	;ターゲットのＶ⇔プレイヤーのＰの汚れが移動
-	;STAIN:(LOCAL:2):3 |= STAIN:(MPLY:0):2
-	;STAIN:(MPLY:0):2 |= STAIN:(LOCAL:2):3
 NEXT
 
 RETURN 1

--- a/ERB/TRAIN/COMF/COMF56_順番にＡ挿入.ERB
+++ b/ERB/TRAIN/COMF/COMF56_順番にＡ挿入.ERB
@@ -149,10 +149,6 @@ FOR LOCAL:0, 0, MTAR_NUM
 
 	;奉仕経験値を得られるコマンドのフラグ
 	TCVAR:(LOCAL:2):4 = 1
-
-	;ターゲットのＡ⇔プレイヤーのＰの汚れが移動
-	;STAIN:(LOCAL:2):3 |= STAIN:(MPLY:0):2
-	;STAIN:(MPLY:0):2 |= STAIN:(LOCAL:2):3
 NEXT
 
 ;体位フラグのセット
@@ -247,10 +243,6 @@ FOR LOCAL:1, 0,  MEQUIP_TARGET_NUM:(ARG:0)
 
 	;奉仕経験値を得られるコマンドのフラグ
 	TCVAR:(LOCAL:2):4 = 1
-
-	;ターゲットのＶ⇔プレイヤーのＰの汚れが移動
-	;STAIN:(LOCAL:2):3 |= STAIN:(MPLY:0):2
-	;STAIN:(MPLY:0):2 |= STAIN:(LOCAL:2):3
 NEXT
 
 RETURN 1

--- a/ERB/TRAIN/COMF/COMF57_代わる代わる挿入.ERB
+++ b/ERB/TRAIN/COMF/COMF57_代わる代わる挿入.ERB
@@ -170,10 +170,6 @@ FOR LOCAL:1, 0, MTAR_NUM
 
 	;奉仕経験値を得られるコマンドのフラグ
 	TCVAR:(LOCAL:2):4 = 1
-
-	;ターゲットのＶ⇔プレイヤーのＰの汚れが移動
-	;STAIN:(LOCAL:2):3 |= STAIN:(MPLY:0):2
-	;STAIN:(MPLY:0):2 |= STAIN:(LOCAL:2):3
 NEXT
 
 ;主導度変化基準値
@@ -267,10 +263,6 @@ FOR LOCAL:1, 0,  MEQUIP_TARGET_NUM:(ARG:0)
 
 	;奉仕経験値を得られるコマンドのフラグ
 	TCVAR:(LOCAL:2):4 = 1
-
-	;ターゲットのＶ⇔プレイヤーのＰの汚れが移動
-	;STAIN:(LOCAL:2):3 |= STAIN:(MPLY:0):2
-	;STAIN:(MPLY:0):2 |= STAIN:(LOCAL:2):3
 NEXT
 
 RETURN 1

--- a/ERB/TRAIN/COMF/COMF58_代わる代わるＡ挿入.ERB
+++ b/ERB/TRAIN/COMF/COMF58_代わる代わるＡ挿入.ERB
@@ -163,10 +163,6 @@ FOR LOCAL:1, 0, MTAR_NUM
 
 	;奉仕経験値を得られるコマンドのフラグ
 	TCVAR:(LOCAL:2):4 = 1
-
-	;ターゲットのＶ⇔プレイヤーのＰの汚れが移動
-	;STAIN:(LOCAL:2):3 |= STAIN:(MPLY:0):2
-	;STAIN:(MPLY:0):2 |= STAIN:(LOCAL:2):3
 NEXT
 
 
@@ -264,10 +260,6 @@ FOR LOCAL:1, 0,  MEQUIP_TARGET_NUM:(ARG:0)
 
 	;奉仕経験値を得られるコマンドのフラグ
 	TCVAR:(LOCAL:2):4 = 1
-
-	;ターゲットのＶ⇔プレイヤーのＰの汚れが移動
-	;STAIN:(LOCAL:2):3 |= STAIN:(MPLY:0):2
-	;STAIN:(MPLY:0):2 |= STAIN:(LOCAL:2):3
 NEXT
 
 RETURN 1

--- a/ERB/TRAIN/COMF/COMF8_アナル舐め.ERB
+++ b/ERB/TRAIN/COMF/COMF8_アナル舐め.ERB
@@ -43,9 +43,6 @@ SIF !IS_PLAYABLE(MPLY:0)
 ;挿入中は不可
 SIF IS_INSERT_MUTUAL(MPLY:0, MTAR:0)
 	RETURN 0
-;性器に愛液、母乳以外の汚れがあり、実行者に汚れ無視がない場合不可
-;SIF (STAIN:(MTAR:0):3 & 14) && !TALENT:(MPLY:0):汚れ無視
-;	RETURN 0
 ;プレイヤーとターゲットが共に拘束中なら不可
 SIF IS_BIND(MPLY:0) && IS_BIND(MTAR:0)
 	RETURN 0
@@ -128,10 +125,6 @@ CALL ADD_SOURCE_INITIATIVE_U(MTAR:0, 150, 0)
 IF TALENT:(MPLY:0):舌使い
 	TIMES SOURCE:(MTAR:0):快Ａ, 1.50
 ENDIF
-
-;奴隷のＶ⇔調教者の口の汚れが移動
-STAIN:(MTAR:0):4 |= STAIN:(MPLY:0):0
-STAIN:(MPLY:0):0 |= STAIN:(MTAR:0):4
 
 ;射精箇所と対象をセット
 CALL STACK_SPERM(MTAR:0, MPLY:0, 8)

--- a/ERB/TRAIN/COMF/COMF9_乳首吸い.ERB
+++ b/ERB/TRAIN/COMF/COMF9_乳首吸い.ERB
@@ -151,10 +151,6 @@ FOR LOCAL:0, 0, MTAR_NUM
 	SOURCE:(LOCAL:1):接触 = 60
 	SOURCE:(LOCAL:1):性行動 = 240
 
-	;奴隷のＢ⇔調教者の指の汚れが移動
-	;STAIN:(LOCAL:1):5 |= STAIN:PLAYER:1
-	;STAIN:PLAYER:1 |= STAIN:(LOCAL:1):5
-
 	;主導権に応じた優越・屈従のソース追加
 	CALL ADD_SOURCE_INITIATIVE_U(LOCAL:1, 80, 0)
 

--- a/ERB/TRAIN/COMF/_COMORDER.ERB
+++ b/ERB/TRAIN/COMF/_COMORDER.ERB
@@ -441,34 +441,6 @@ IF TCVAR:(ARG:0):60
 	CALL COM_ORDER_ELEMENT(ARG:0, "媚薬", 6)
 ENDIF
 
-;汚れの判定
-;IF !TALENT:(ARG:0):汚れ無視
-;	LOCAL:0 = 0
-;	;愛液の汚れ
-;	SIF STAIN:PLAYER:2 & 1
-;		LOCAL:0 += 1
-;	;精液の汚れ
-;	SIF STAIN:PLAYER:2 & 4
-;		LOCAL:0 += 3
-;	;アナルの汚れ
-;	SIF STAIN:PLAYER:2 & 8
-;		LOCAL:0 += 7
-;	SIF STAIN:PLAYER:2 & 16
-;		LOCAL:0 += 15
-;	SIF TALENT:(ARG:0):汚臭鈍感
-;		LOCAL:0 /= 3
-;	SIF TALENT:(ARG:0):汚臭敏感
-;		LOCAL:0 *= 2
-
-	;汚れ影響が小さい
-;	LOCAL:0 /= 3
-
-	;汚れあり
-;	IF LOCAL:0 > 0
-;		CALL COM_ORDER_ELEMENT(ARG:0, "汚れあり", -LOCAL:0)
-;	ENDIF
-;ENDIF
-
 ;合意
 IF !TALENT:(ARG:0):合意 && !TALENT:(ARG:0):親友
 	IF TALENT:(ARG:0):子供人質
@@ -559,34 +531,6 @@ IF TCVAR:(ARG:0):60
 	CALL COM_ORDER_ELEMENT(ARG:0, "媚薬", 6)
 ENDIF
 
-;汚れの判定
-;IF !TALENT:(ARG:0):汚れ無視
-;	LOCAL:0 = 0
-;	;愛液の汚れ
-;	SIF STAIN:PLAYER:2 & 1
-;		LOCAL:0 += 1
-;	;精液の汚れ
-;	SIF STAIN:PLAYER:2 & 4
-;		LOCAL:0 += 3
-;	;アナルの汚れ
-;	SIF STAIN:PLAYER:2 & 8
-;		LOCAL:0 += 7
-;	SIF STAIN:PLAYER:2 & 16
-;		LOCAL:0 += 15
-;	SIF TALENT:(ARG:0):汚臭鈍感
-;		LOCAL:0 /= 3
-;	SIF TALENT:(ARG:0):汚臭敏感
-;		LOCAL:0 *= 2
-
-	;汚れ影響が小さい
-;	LOCAL:0 /= 3
-
-	;汚れあり
-;	IF LOCAL:0 > 0
-;		CALL COM_ORDER_ELEMENT(ARG:0, "汚れあり", -LOCAL:0)
-;	ENDIF
-;ENDIF
-
 ;合意
 IF !TALENT:(ARG:0):合意 && !TALENT:(ARG:0):親友
 	CALL COM_ORDER_ELEMENT(ARG:0, "合意なし", -20)
@@ -660,34 +604,6 @@ ENDIF
 IF TCVAR:(ARG:0):60
 	CALL COM_ORDER_ELEMENT(ARG:0, "媚薬", 6)
 ENDIF
-
-;汚れの判定
-;IF !TALENT:(ARG:0):汚れ無視
-;	LOCAL:0 = 0
-;	;愛液の汚れ
-;	SIF STAIN:PLAYER:2 & 1
-;		LOCAL:0 += 1
-;	;精液の汚れ
-;	SIF STAIN:PLAYER:2 & 4
-;		LOCAL:0 += 3
-;	;アナルの汚れ
-;	SIF STAIN:PLAYER:2 & 8
-;		LOCAL:0 += 7
-;	SIF STAIN:PLAYER:2 & 16
-;		LOCAL:0 += 15
-;	SIF TALENT:(ARG:0):汚臭鈍感
-;		LOCAL:0 /= 3
-;	SIF TALENT:(ARG:0):汚臭敏感
-;		LOCAL:0 *= 2
-
-	;汚れ影響が小さい
-;	LOCAL:0 /= 3
-
-	;汚れあり
-;	IF LOCAL:0 > 0
-;		CALL COM_ORDER_ELEMENT(ARG:0, "汚れあり", -LOCAL:0)
-;	ENDIF
-;ENDIF
 
 ;合意
 IF !TALENT:(ARG:0):合意 && !TALENT:(ARG:0):親友


### PR DESCRIPTION
﻿# 概要
STAINにかかわる処理を一括削除
# もう少し詳しく
STAINはかつて調教コマンドの制約として働いていたが現在では分岐として利用されていない。だがしかし、コメントアウトであったり、一切処置がされていなかったりでSTAINを直接、間接に扱ったコードは多い。そのため、コードの意図が明確になるようにSTAINにかかわる処理を削除する
# 留意点
今からかつてのSTAINの資産を利用して何かやろうとしてるならこのパッチは余計なお世話
あと、一か所条件文で気になった場所にTODO:を一個差し込んだ