### PR TITLE
FIX:FUCK関数でCFLAGが減少する場合に閾値を割っても陥落素質を喪失しなかった問題を修正

### DIFF
--- a/ERB/SYSTEM/_FUNCTION.ERB
+++ b/ERB/SYSTEM/_FUNCTION.ERB
@@ -2101,9 +2101,7 @@ ENDIF
 RETURNF GET_SPERM_NAME(ARG:0)
 
 ;-------------------------------------------------
-;ARG:0のCFLAGを参照し、閾値を割っているかどうか確認する。
-;
-;ARG:2に1を指定すると、タチ役関係の素質を対象外にする
+;対象のCFLAGを参照し、閾値を割っていると烙印を除く陥落素質を全て消去する関数
 ;-------------------------------------------------
 @CHECK_LOSE_RELATION_TALENT(対象)
 #DIM 対象
@@ -2126,7 +2124,7 @@ ENDIF
 
 IF 喪失
 	CALL COLOR_PRINTW(@"%ANAME(対象)%の中で、%ANAME(MASTER)%への想いよりも快楽が勝った……", カラー_警告)
-	CALL LOSE_RELATION_TALENT
+	CALL LOSE_RELATION_TALENT(対象)
 ENDIF
 
 ;-------------------------------------------------


### PR DESCRIPTION
# 留意点
関数の性質が大きく変わるため，バージョンアップ時には詳しいアナウンスが必要かも